### PR TITLE
Build separate shared library for client

### DIFF
--- a/module/Makefile
+++ b/module/Makefile
@@ -23,7 +23,13 @@ LIBS=-lssl -lcrypto
 all: local-shared-build
 
 #   install the shared object file into Apache 
-install: install-modules-yes
+install: install-modules-yes install-client
+
+liblauth-client.so:
+	cd client && bazel build ...
+
+install-client: liblauth-client.so
+	install -v client/bazel-bin/lauth/liblauth-client.so /usr/lib/`gcc -dumpmachine`
 
 #   cleanup
 clean:

--- a/module/client/lauth/BUILD
+++ b/module/client/lauth/BUILD
@@ -1,9 +1,10 @@
 cc_library(
   name = "lauth-client",
-  srcs = glob(["*.cpp"]),
+  srcs = glob(["*.cpp", "v1/*.h", "v1/*.cpp"]),
   hdrs = glob(["*.h"]),
   deps = ["//include:cpp-httplib", "//include:nlohmann-json"],
   linkopts = ["-lssl", "-lcrypto"],
+  alwayslink = True,
   # strip_include_prefix = ".",
   visibility = ["//visibility:public"],
 )

--- a/module/client/lauth/client.cpp
+++ b/module/client/lauth/client.cpp
@@ -16,18 +16,4 @@ namespace mlibrary::lauth::v1 {
         json user = json::parse(response->body);
         return user.get<User>();
     };
-
-    void to_json(nlohmann::json& j, const User& user) {
-        j = nlohmann::json {
-            {"userid", user.userid},
-            {"givenName", user.givenName},
-            {"surname", user.surname},
-        };
-    }
-
-    void from_json(const nlohmann::json& j, User& user) {
-        j.at("userid").get_to(user.userid);
-        j.at("givenName").get_to(user.givenName);
-        j.at("surname").get_to(user.surname);
-    }
 };

--- a/module/client/lauth/client.h
+++ b/module/client/lauth/client.h
@@ -1,47 +1,15 @@
 #ifndef _LAUTH_CLIENT_H_
 #define _LAUTH_CLIENT_H_
 
-#include <string>
-
 #define CPPHTTPLIB_OPENSSL_SUPPORT
 #include <httplib.h>
 #include <json.hpp>
 
+#include "lauth/v1/user.h"
+
+#include <string>
+
 namespace mlibrary::lauth::v1 {
-
-    struct User {
-        std::string userid;
-        std::string givenName;
-        std::string surname;
-    };
-
-    void to_json(nlohmann::json& j, const User& user);
-    void from_json(const nlohmann::json& j, User& user);
-
-
-/* countryName */
-/* description */
-/* dlpsCourse */
-/* dlpsDeleted */
-/* dlpsExpiryTime */
-/* string dlpsKey */
-/* string givenName */
-/* string initials\": null, */
-/* lastModifiedBy\": \"root\", */
-/* lastModifiedTime\": \"2022-07-06 13:14:33 +0000\", */
-/* localityName\": null, */
-/* manager\": 0, */
-/* organizationalStatus\": null, */
-/* organizationalUnitName\": null, */
-/* personalTitle\": null, */
-/* postalAddress\": null, */
-/* postalCode\": null, */
-/* rfc822Mailbox\": \"lit-cs-sysadmin@umich.edu\", */
-/* stateOrProvinceName\": null, */
-/* string surname\": \"User\", */
-/* telephoneNumber\": null, */
-/* userPassword\": \"!none\", */
-/* string userid\": \"root\" */
 
     class Client {
         public:

--- a/module/client/lauth/v1/user.cpp
+++ b/module/client/lauth/v1/user.cpp
@@ -1,0 +1,20 @@
+#include <string>
+#include <json.hpp>
+
+#include "lauth/v1/user.h"
+
+namespace mlibrary::lauth::v1 {
+    void to_json(nlohmann::json& j, const User& user) {
+        j = nlohmann::json {
+            {"userid", user.userid},
+            {"givenName", user.givenName},
+            {"surname", user.surname},
+        };
+    }
+
+    void from_json(const nlohmann::json& j, User& user) {
+        j.at("userid").get_to(user.userid);
+        j.at("givenName").get_to(user.givenName);
+        j.at("surname").get_to(user.surname);
+    }
+}

--- a/module/client/lauth/v1/user.h
+++ b/module/client/lauth/v1/user.h
@@ -1,0 +1,43 @@
+#ifndef _LAUTH_V1_USER_H_
+#define _LAUTH_V1_USER_H_
+
+#include <string>
+
+namespace mlibrary::lauth::v1 {
+
+    struct User {
+        std::string userid;
+        std::string givenName;
+        std::string surname;
+    };
+
+/* countryName */
+/* description */
+/* dlpsCourse */
+/* dlpsDeleted */
+/* dlpsExpiryTime */
+/* string dlpsKey */
+/* string givenName */
+/* string initials\": null, */
+/* lastModifiedBy\": \"root\", */
+/* lastModifiedTime\": \"2022-07-06 13:14:33 +0000\", */
+/* localityName\": null, */
+/* manager\": 0, */
+/* organizationalStatus\": null, */
+/* organizationalUnitName\": null, */
+/* personalTitle\": null, */
+/* postalAddress\": null, */
+/* postalCode\": null, */
+/* rfc822Mailbox\": \"lit-cs-sysadmin@umich.edu\", */
+/* stateOrProvinceName\": null, */
+/* string surname\": \"User\", */
+/* telephoneNumber\": null, */
+/* userPassword\": \"!none\", */
+/* string userid\": \"root\" */
+
+
+    void to_json(nlohmann::json& j, const User& user);
+    void from_json(const nlohmann::json& j, User& user);
+};
+
+#endif

--- a/module/conf/lauth.conf
+++ b/module/conf/lauth.conf
@@ -1,6 +1,8 @@
 LoadFile /usr/lib/${cpu_arch}/libssl.so.1.1
 LoadFile /usr/lib/${cpu_arch}/libstdc++.so.6
 LoadModule lauth_module modules/mod_lauth.so
+LoadModule rewrite_module modules/mod_rewrite.so
+LoadModule remoteip_module modules/mod_remoteip.so
 <Location /lauth>
 SetHandler lauth
 </Location>

--- a/module/mod_lauth.cpp
+++ b/module/mod_lauth.cpp
@@ -43,6 +43,7 @@
 #include "ap_config.h"
 
 #include "lauth/client.h"
+
 #include <string>
 
 using namespace mlibrary::lauth::v1;

--- a/module/modules.mk
+++ b/module/modules.mk
@@ -1,10 +1,4 @@
-mod_lauth.la: mod_lauth.slo lauth-client.slo
-	$(SH_LINK) -rpath $(libexecdir) -module -avoid-version  mod_lauth.lo lauth-client.lo
+mod_lauth.la: liblauth-client.so mod_lauth.slo
+	$(SH_LINK) -rpath $(libexecdir) -module -avoid-version  mod_lauth.lo -Lclient/bazel-bin/lauth -llauth-client
 DISTCLEAN_TARGETS = modules.mk
 shared =  mod_lauth.la
-
-lauth-client.la: lauth-client.slo
-lauth-client.lo: client/lauth/*.cpp
-	$(LIBTOOL) --mode=compile $(CXX_COMPILE) $(LTCFLAGS) -c $< -o lauth-client.lo && touch $@
-lauth-client.slo: client/lauth/*.cpp
-	$(LIBTOOL) --mode=compile $(BASE_CXX) $(SHLTCFLAGS) -c $< -o lauth-client.lo && touch $@


### PR DESCRIPTION
By building the shared library in Bazel and linking it from the module,
we can split out and reorganize the client source however TDD guides us.