### PR TITLE
Restructure test-site to be more explanatory

### DIFF
--- a/module/test-site/web/exemption/global/index.html
+++ b/module/test-site/web/exemption/global/index.html
@@ -1,0 +1,1 @@
+allowed by subpath exemption in global configuration

--- a/module/test-site/web/exemption/index.html
+++ b/module/test-site/web/exemption/index.html
@@ -1,0 +1,1 @@
+denied for any requester (no grants, no exemption)

--- a/module/test-site/web/exemption/vhost/index.html
+++ b/module/test-site/web/exemption/vhost/index.html
@@ -1,0 +1,1 @@
+allowed by subpath exemption in virtual host configuration

--- a/module/test-site/web/index.html
+++ b/module/test-site/web/index.html
@@ -1,1 +1,1 @@
-base static
+allowed by implicit public designation (unregistered URL)

--- a/module/test-site/web/lit-authn-or-ip/index.html
+++ b/module/test-site/web/lit-authn-or-ip/index.html
@@ -1,1 +1,0 @@
-lit-authn-or-ip static

--- a/module/test-site/web/lit-authn/exempted_toplevel/index.html
+++ b/module/test-site/web/lit-authn/exempted_toplevel/index.html
@@ -1,1 +1,0 @@
-lit-authn exempted toplevel

--- a/module/test-site/web/lit-authn/exempted_vserver/index.html
+++ b/module/test-site/web/lit-authn/exempted_vserver/index.html
@@ -1,1 +1,0 @@
-lit-authn exempted vserver

--- a/module/test-site/web/lit-authn/index.html
+++ b/module/test-site/web/lit-authn/index.html
@@ -1,1 +1,0 @@
-lit-authn static

--- a/module/test-site/web/lit-ip/index.html
+++ b/module/test-site/web/lit-ip/index.html
@@ -1,1 +1,0 @@
-lit-ip static

--- a/module/test-site/web/network/index.html
+++ b/module/test-site/web/network/index.html
@@ -1,0 +1,1 @@
+allowed by authorized network

--- a/module/test-site/web/public/index.html
+++ b/module/test-site/web/public/index.html
@@ -1,1 +1,1 @@
-public static
+allowed by explicit public designation

--- a/module/test-site/web/user-or-network/index.html
+++ b/module/test-site/web/user-or-network/index.html
@@ -1,0 +1,1 @@
+allowed by user authentication or authorized network

--- a/module/test-site/web/user/index.html
+++ b/module/test-site/web/user/index.html
@@ -1,0 +1,1 @@
+allowed by user authentication

--- a/test/restrictions/public_spec.rb
+++ b/test/restrictions/public_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "Access to public resources" do
   context "when using an off-campus computer" do
     context "when not logged in" do
       it "is allowed" do
-        response = Faraday.get("http://www.lauth.local/public/")
+        response = Faraday.get("#{TestSite::URL}/public/")
         expect(response).to be_success
       end
     end

--- a/test/restrictions/umich_login_spec.rb
+++ b/test/restrictions/umich_login_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe "Access to resources restricted to specific users" do
   context "when using an off-campus computer" do
     context "when not logged in" do
       it "results in authentication request" do
-        response = website.get("/lit-authn/")
+        response = website.get("/user/")
         expect(response.status).to eq HttpCodes::UNAUTHORIZED
       end
     end
 
     context "when logged in as an unauthorized user" do
       xit "is forbidden" do
-        response = website.get("/lit-authn/") do |req|
+        response = website.get("/user/") do |req|
           req.headers["Authorization"] = basic_auth_bad_user
         end
 
@@ -23,6 +23,6 @@ RSpec.describe "Access to resources restricted to specific users" do
   end
 
   def website
-    @website ||= Faraday.new("http://www.lauth.local")
+    @website ||= Faraday.new(TestSite::URL)
   end
 end

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -19,6 +19,10 @@ module BasicAuth
   end
 end
 
+module TestSite
+  URL = ENV["TEST_URL_BASE"] || "http://www.lauth.local"
+end
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
This expands the concepts that were implied by the previous symbolic names (e.g., lit-authn-or-ip to user-or-network) and includes a description of why a request for one of these "collections" is expected to be allowed or denied.

This also adjusts the existing system tests to the new paths and puts in a rudimentary way to supply the test site URL via the TEST_URL_BASE environment variable.