### PR TITLE
Revert default UID to 1000 and allow .env override

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -3,8 +3,8 @@ FROM ruby:${RUBY_VERSION}
 
 ARG BUNDLER_VERSION=2.4.21
 ARG UNAME=lauth
-ARG UID=1001
-ARG GID=1001
+ARG UID=1000
+ARG GID=1000
 
 LABEL maintainer="dla-staff@umich.edu"
 

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -3,8 +3,8 @@ FROM ruby:${RUBY_VERSION}
 
 ARG BUNDLER_VERSION=2.4.21
 ARG UNAME=lauth
-ARG UID=1001
-ARG GID=1001
+ARG UID=1000
+ARG GID=1000
 
 LABEL maintainer="dla-staff@umich.edu"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,9 @@ services:
     build:
       context: ./
       dockerfile: ./cli/Dockerfile
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
     profiles: ["test", "cli"]
     depends_on:
       api:
@@ -28,6 +31,9 @@ services:
     build:
       context: ./
       dockerfile: ./api/Dockerfile
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
     depends_on:
       mariadb:
         condition: "service_healthy"
@@ -75,7 +81,7 @@ services:
       interval: "10s"
       timeout: "10s"
       retries: 3
-      start_period: "10s"
+      start_period: "2s"
       start_interval: "1s"
 
   apache:
@@ -112,6 +118,9 @@ services:
     build:
       context: ./
       dockerfile: ./test/Dockerfile
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
     depends_on:
       apache:
         condition: "service_healthy"

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -12,6 +12,7 @@ RUN gem install bundler:${BUNDLER_VERSION}
 
 RUN groupadd -g ${GID} -o ${UNAME}
 RUN useradd -m -d /lauth -u ${UID} -g ${GID} -o -s /bin/bash ${UNAME}
+RUN chown -R ${UID}:${GID} /usr/local/bundle
 RUN mkdir -p /lauth/test && chown ${UID}:${GID} /lauth/test
 RUN mkdir -p /gems && chown ${UID}:${GID} /gems
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -3,8 +3,8 @@ FROM ruby:${RUBY_VERSION}
 
 ARG BUNDLER_VERSION=2.4.21
 ARG UNAME=lauth
-ARG UID=1001
-ARG GID=1001
+ARG UID=1000
+ARG GID=1000
 
 LABEL maintainer="dla-staff@umich.edu"
 


### PR DESCRIPTION
Docker Compose silently uses .env if it is present. This change passes along a UID or GID in the Compose environment (via .env or arguments, NOT everything from your shell environment) to the build args of the Dockerfiles. All of the defaults are the usual 1000, but you can use whatever you need (Linux users should likely use their own UID/GID, and this likely applies in GitHub Actions as well).