### PR TITLE
One step back

### DIFF
--- a/apache/client/include/lauth/api_client.hpp
+++ b/apache/client/include/lauth/api_client.hpp
@@ -9,7 +9,7 @@
 namespace mlibrary::lauth {
   class ApiClient {
     public:
-      ApiClient() : client(std::make_unique<HttpClient>("http://localhost:9000")) {};
+      ApiClient(const std::string& url) : client(std::make_unique<HttpClient>(url)) {};
       ApiClient(std::unique_ptr<HttpClient>&& client) : client(std::move(client)) {};
       ApiClient(const ApiClient&) = delete;
       ApiClient& operator=(const ApiClient&) = delete;

--- a/apache/client/include/lauth/authorizer.hpp
+++ b/apache/client/include/lauth/authorizer.hpp
@@ -10,7 +10,7 @@
 namespace mlibrary::lauth {
   class Authorizer {
     public:
-      Authorizer() : client(std::make_unique<ApiClient>()) {};
+      Authorizer(const std::string& url) : client(std::make_unique<ApiClient>(url)) {};
       Authorizer(std::unique_ptr<ApiClient>&& client) : client(std::move(client)) {};
       Authorizer(const Authorizer&) = delete;
       Authorizer& operator=(const Authorizer&) = delete;

--- a/apache/client/include/lauth/authorizer.hpp
+++ b/apache/client/include/lauth/authorizer.hpp
@@ -18,7 +18,6 @@ namespace mlibrary::lauth {
       Authorizer& operator=(const Authorizer&&) = delete;
       virtual ~Authorizer() = default;
 
-      bool isPasswordOnly(std::string url);
       virtual bool isAllowed(Request req);
 
     protected:

--- a/apache/client/include/lauth/http_client.hpp
+++ b/apache/client/include/lauth/http_client.hpp
@@ -3,6 +3,8 @@
 
 #include "lauth/request.hpp"
 
+#include <string>
+
 namespace mlibrary::lauth {
   class HttpClient {
     public:

--- a/apache/client/include/lauth/http_client.hpp
+++ b/apache/client/include/lauth/http_client.hpp
@@ -1,8 +1,6 @@
 #ifndef __LAUTH_HTTP_CLIENT_HPP__
 #define __LAUTH_HTTP_CLIENT_HPP__
 
-#include "lauth/request.hpp"
-
 #include <string>
 
 namespace mlibrary::lauth {
@@ -11,9 +9,7 @@ namespace mlibrary::lauth {
       HttpClient(const std::string& baseUrl) : baseUrl(baseUrl) {};
       virtual ~HttpClient() = default;
 
-      virtual bool isAllowed(Request req);
       virtual std::string get(const std::string& path); 
-
 
     protected:
       const std::string baseUrl;

--- a/apache/client/src/lauth/api_client.cpp
+++ b/apache/client/src/lauth/api_client.cpp
@@ -8,6 +8,6 @@ namespace mlibrary::lauth {
     std::stringstream url;
     url << "/users/" << req.user << "/is_allowed";
     std::string result = client->get(url.str());
-    return client->isAllowed(req);
+    return result == "yes";
   }
 }

--- a/apache/client/src/lauth/api_client.cpp
+++ b/apache/client/src/lauth/api_client.cpp
@@ -1,8 +1,13 @@
 #include "lauth/api_client.hpp"
 
+#include <sstream>
+#include <string>
+
 namespace mlibrary::lauth {
   bool ApiClient::isAllowed(Request req) {
+    std::stringstream url;
+    url << "/users/" << req.user << "/is_allowed";
+    std::string result = client->get(url.str());
     return client->isAllowed(req);
   }
 }
-

--- a/apache/client/src/lauth/authorizer.cpp
+++ b/apache/client/src/lauth/authorizer.cpp
@@ -3,10 +3,6 @@
 #include <string>
 
 namespace mlibrary::lauth {
-  bool Authorizer::isPasswordOnly(std::string url) {
-    return false;
-  }
-
   bool Authorizer::isAllowed(Request req) {
     return client->isAllowed(req);
   }

--- a/apache/client/src/lauth/http_client.cpp
+++ b/apache/client/src/lauth/http_client.cpp
@@ -3,10 +3,6 @@
 #include <httplib.h>
 
 namespace mlibrary::lauth {
-  bool HttpClient::isAllowed(Request req) {
-    return req.user == "authorized";
-  }
-
   std::string HttpClient::get(const std::string& path) {
     httplib::Client client(baseUrl);
 

--- a/apache/client/src/lauth/http_client.cpp
+++ b/apache/client/src/lauth/http_client.cpp
@@ -8,7 +8,7 @@ namespace mlibrary::lauth {
 
     auto res = client.Get(path);
 
-    return res->body;
+    return res ? res->body : "";
   }
 }
 

--- a/apache/client/test/lauth/api_client_test.cpp
+++ b/apache/client/test/lauth/api_client_test.cpp
@@ -10,7 +10,37 @@ using ::testing::Return;
 
 using namespace mlibrary::lauth;
 
-TEST(ApiClientTest, allowed_by_mock) {
+TEST(ApiClient, allowed_by_mock_http_client) {
+  auto client = std::make_unique<MockHttpClient>();
+  EXPECT_CALL(*client, get("/users/authorized/is_allowed")).WillOnce(Return("yes"));
+  EXPECT_CALL(*client, isAllowed(_)).WillOnce(Return(true));
+  ApiClient api_client(std::move(client));
+
+  Request req {
+    .user = "authorized",
+  };
+
+  auto allowed = api_client.isAllowed(req);
+
+  EXPECT_THAT(allowed, true);
+}
+
+TEST(ApiClient, denied_by_mock_http_client) {
+  auto client = std::make_unique<MockHttpClient>();
+  EXPECT_CALL(*client, get("/users/unauthorized/is_allowed")).WillOnce(Return("no"));
+  EXPECT_CALL(*client, isAllowed(_)).WillOnce(Return(false));
+  ApiClient api_client(std::move(client));
+
+  Request req {
+    .user = "unauthorized",
+  };
+
+  auto allowed = api_client.isAllowed(req);
+
+  EXPECT_THAT(allowed, false);
+}
+
+TEST(ApiClient, allowed_by_mock) {
   auto client = std::make_unique<MockHttpClient>();
   EXPECT_CALL(*client, isAllowed(_)).WillOnce(Return(true));
   ApiClient api_client(std::move(client));
@@ -22,7 +52,7 @@ TEST(ApiClientTest, allowed_by_mock) {
   EXPECT_THAT(allowed, true);
 }
 
-TEST(ApiClientTest, denied_by_mock) {
+TEST(ApiClient, denied_by_mock) {
   auto client = std::make_unique<MockHttpClient>();
   EXPECT_CALL(*client, isAllowed(_)).WillOnce(Return(false));
   ApiClient api_client(std::move(client));
@@ -34,7 +64,7 @@ TEST(ApiClientTest, denied_by_mock) {
   EXPECT_THAT(allowed, false);
 }
 
-TEST(ApiClientTest, a_request_with_no_user_is_denied) {
+TEST(ApiClient, a_request_with_no_user_is_denied) {
   ApiClient client;
   Request request;
 
@@ -43,7 +73,7 @@ TEST(ApiClientTest, a_request_with_no_user_is_denied) {
 }
 
 
-TEST(ApiClientTest, a_request_with_authorized_user_is_allowed) {
+TEST(ApiClient, a_request_with_authorized_user_is_allowed) {
   ApiClient client;
   Request request;
 
@@ -52,7 +82,7 @@ TEST(ApiClientTest, a_request_with_authorized_user_is_allowed) {
   EXPECT_THAT(result, true);
 }
 
-TEST(ApiClientTest, a_request_with_unauthorized_user_is_denied) {
+TEST(ApiClient, a_request_with_unauthorized_user_is_denied) {
   ApiClient client;
   Request request;
 

--- a/apache/client/test/lauth/api_client_test.cpp
+++ b/apache/client/test/lauth/api_client_test.cpp
@@ -13,7 +13,6 @@ using namespace mlibrary::lauth;
 TEST(ApiClient, allowed_by_mock_http_client) {
   auto client = std::make_unique<MockHttpClient>();
   EXPECT_CALL(*client, get("/users/authorized/is_allowed")).WillOnce(Return("yes"));
-  EXPECT_CALL(*client, isAllowed(_)).WillOnce(Return(true));
   ApiClient api_client(std::move(client));
 
   Request req {
@@ -28,36 +27,11 @@ TEST(ApiClient, allowed_by_mock_http_client) {
 TEST(ApiClient, denied_by_mock_http_client) {
   auto client = std::make_unique<MockHttpClient>();
   EXPECT_CALL(*client, get("/users/unauthorized/is_allowed")).WillOnce(Return("no"));
-  EXPECT_CALL(*client, isAllowed(_)).WillOnce(Return(false));
   ApiClient api_client(std::move(client));
 
   Request req {
     .user = "unauthorized",
   };
-
-  auto allowed = api_client.isAllowed(req);
-
-  EXPECT_THAT(allowed, false);
-}
-
-TEST(ApiClient, allowed_by_mock) {
-  auto client = std::make_unique<MockHttpClient>();
-  EXPECT_CALL(*client, isAllowed(_)).WillOnce(Return(true));
-  ApiClient api_client(std::move(client));
-
-  Request req {};
-
-  auto allowed = api_client.isAllowed(req);
-
-  EXPECT_THAT(allowed, true);
-}
-
-TEST(ApiClient, denied_by_mock) {
-  auto client = std::make_unique<MockHttpClient>();
-  EXPECT_CALL(*client, isAllowed(_)).WillOnce(Return(false));
-  ApiClient api_client(std::move(client));
-
-  Request req {};
 
   auto allowed = api_client.isAllowed(req);
 

--- a/apache/client/test/lauth/api_client_test.cpp
+++ b/apache/client/test/lauth/api_client_test.cpp
@@ -16,6 +16,8 @@ TEST(ApiClient, allowed_by_mock_http_client) {
   ApiClient api_client(std::move(client));
 
   Request req {
+    .ip = "",
+    .uri = "",
     .user = "authorized",
   };
 
@@ -30,6 +32,8 @@ TEST(ApiClient, denied_by_mock_http_client) {
   ApiClient api_client(std::move(client));
 
   Request req {
+    .ip = "",
+    .uri = "",
     .user = "unauthorized",
   };
 

--- a/apache/client/test/lauth/api_client_test.cpp
+++ b/apache/client/test/lauth/api_client_test.cpp
@@ -39,7 +39,7 @@ TEST(ApiClient, denied_by_mock_http_client) {
 }
 
 TEST(ApiClient, a_request_with_no_user_is_denied) {
-  ApiClient client;
+  ApiClient client("http://localhost:9000");
   Request request;
 
   bool result = client.isAllowed(request);
@@ -48,7 +48,7 @@ TEST(ApiClient, a_request_with_no_user_is_denied) {
 
 
 TEST(ApiClient, a_request_with_authorized_user_is_allowed) {
-  ApiClient client;
+  ApiClient client("http://localhost:9000");
   Request request;
 
   request.user = "authorized";
@@ -57,7 +57,7 @@ TEST(ApiClient, a_request_with_authorized_user_is_allowed) {
 }
 
 TEST(ApiClient, a_request_with_unauthorized_user_is_denied) {
-  ApiClient client;
+  ApiClient client("http://localhost:9000");
   Request request;
 
   request.user = "unauthorized";

--- a/apache/client/test/lauth/authorizer_test.cpp
+++ b/apache/client/test/lauth/authorizer_test.cpp
@@ -22,7 +22,9 @@ TEST(AuthorizerTest, AllowsAccessWhenApiSaysAuthorized) {
   Authorizer authorizer(std::move(client));
 
   Request req {
-    .user = "lauth-allowed"
+    .ip = "",
+    .uri = "",
+    .user = "lauth-allowed",
   };
   auto allowed = authorizer.isAllowed(req);
 
@@ -35,7 +37,9 @@ TEST(AuthorizerTest, DeniesAccessWhenApiSaysUnauthorized) {
   Authorizer authorizer(std::move(client));
 
   Request req {
-    .user = "lauth-denied"
+    .ip = "",
+    .uri = "",
+    .user = "lauth-denied",
   };
   auto allowed = authorizer.isAllowed(req);
 

--- a/apache/client/test/lauth/mocks.hpp
+++ b/apache/client/test/lauth/mocks.hpp
@@ -8,6 +8,7 @@ using namespace mlibrary::lauth;
 
 class MockApiClient : public ApiClient {
     public:
+    MockApiClient() : ApiClient("http://localhost:9000") {};
     MOCK_METHOD(bool, isAllowed, (Request), (override));
 };
 

--- a/apache/client/test/lauth/mocks.hpp
+++ b/apache/client/test/lauth/mocks.hpp
@@ -14,7 +14,6 @@ class MockApiClient : public ApiClient {
 class MockHttpClient : public HttpClient {
     public:
     MockHttpClient() : HttpClient("http://localhost:9000") {};
-    MOCK_METHOD(bool, isAllowed, (Request), (override));
     MOCK_METHOD(std::string, get, (const std::string&), (override));
 };
 

--- a/apache/client/test/mock_service.cpp
+++ b/apache/client/test/mock_service.cpp
@@ -14,23 +14,23 @@ int main(int argc, char **argv) {
     port = server.bind_to_any_port(address);
   }
 
-  server.Get("/", [](const Request &req, Response &res) {
+  server.Get("/", [](const Request &, Response &res) {
     res.set_content("Root", "text/plain");
   });
 
-  server.Get("/ping", [](const Request &req, Response &res) {
+  server.Get("/ping", [](const Request &, Response &res) {
     res.set_content("pong", "text/plain");
   });
 
-  server.Get("/users/authorized/is_allowed", [](const Request &req, Response &res) {
+  server.Get("/users/authorized/is_allowed", [](const Request &, Response &res) {
     res.set_content("yes", "text/plain");
   });
 
-  server.Get("/users/unauthorized/is_allowed", [](const Request &req, Response &res) {
+  server.Get("/users/unauthorized/is_allowed", [](const Request &, Response &res) {
     res.set_content("no", "text/plain");
   });
 
-  server.Get("/stop", [&](const Request &req, Response &res) {
+  server.Get("/stop", [&](const Request &, Response &res) {
     res.set_content("Shutting down server...", "text/plain");
     server.stop();
   });

--- a/apache/client/test/mock_service.cpp
+++ b/apache/client/test/mock_service.cpp
@@ -22,6 +22,14 @@ int main(int argc, char **argv) {
     res.set_content("pong", "text/plain");
   });
 
+  server.Get("/users/authorized/is_allowed", [](const Request &req, Response &res) {
+    res.set_content("yes", "text/plain");
+  });
+
+  server.Get("/users/unauthorized/is_allowed", [](const Request &req, Response &res) {
+    res.set_content("no", "text/plain");
+  });
+
   server.Get("/stop", [&](const Request &req, Response &res) {
     res.set_content("Shutting down server...", "text/plain");
     server.stop();

--- a/apache/module/mod_lauth.cpp
+++ b/apache/module/mod_lauth.cpp
@@ -38,17 +38,13 @@ static authz_status lauth_check_authorization(request_rec *r,
        return AUTHZ_DENIED_NO_USER;
     }
 
-    if (Authorizer().isPasswordOnly(r->uri) && !r->user) {
-      return AUTHZ_DENIED_NO_USER;
-    }
-
     Request req {
       .ip = r->useragent_ip ? std::string(r->useragent_ip) : "",
       .uri = r->uri ? std::string(r->uri) : "",
       .user = r->user ? std::string(r->user) : ""
     };
 
-    return Authorizer().isAllowed(req) ? AUTHZ_GRANTED : AUTHZ_DENIED;
+    return Authorizer("http://api-mock:9000").isAllowed(req) ? AUTHZ_GRANTED : AUTHZ_DENIED;
 }
 
 static const authz_provider authz_lauth_provider =

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,32 +77,32 @@ services:
       start_interval: "1s"
 
   module:
+    profiles: [ "dev" ]
     build:
       context: ./
       dockerfile: ./apache/Dockerfile
       target: tests
-    profiles: ["dev"]
     volumes:
       - ./apache/client:/lauth/apache/client
       - ./apache/module:/lauth/apache/module
       - build_cache:/lauth/apache/build
 
   mock-api:
+    profiles: [ "integration" ]
     build:
       context: ./
       dockerfile: ./apache/Dockerfile
       target: tests
-    profiles: ["integration"]
     ports:
       - "127.0.0.1:9000:9000"
     command: ["./http-service", "9000"]
 
   client-tests:
+    profiles: [ "test" ]
     build:
       context: ./
       dockerfile: ./apache/Dockerfile
       target: client-tests
-    profiles: ["test"]
 
   test:
     profiles: ["test"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,17 +88,28 @@ services:
       - build_cache:/lauth/apache/build
 
   mock-api:
-    profiles: [ "integration" ]
+    profiles: [ "test", "integration" ]
     build:
       context: ./
       dockerfile: ./apache/Dockerfile
       target: tests
     ports:
       - "127.0.0.1:9000:9000"
+    healthcheck:
+      test: [ "CMD", "curl", "--fail", "http://127.0.0.1:9000", "--output", "/dev/null", "--silent" ]
+      interval: "10s"
+      timeout: "10s"
+      retries: 3
+      start_period: "2s"
+      start_interval: "1s"
     command: ["./http-service", "9000"]
 
   client-tests:
     profiles: [ "test" ]
+    depends_on:
+      mock-api:
+        condition:
+          "service_healthy"
     build:
       context: ./
       dockerfile: ./apache/Dockerfile


### PR DESCRIPTION
Hard coded URL string for API service and client test dependency on mock-api service.

NOTE: CI still failing on GitHub even though mock-api service is running which should be resolved once the API URL is configurable.