### PR TITLE
Remove integration tests from default 'tests' in client

### DIFF
--- a/apache/client/meson.build
+++ b/apache/client/meson.build
@@ -74,7 +74,7 @@ if get_option('tests')
   )
 
   test('lauth-test', tests)
-  test('lauth-integration-test', integration_tests)
+
 endif
 
 os = host_machine.system()


### PR DESCRIPTION
It's annoying for these to fail because a service isn't running when you're trying to TDD within the app.