### PR TITLE
Enable JSON_DIAGNOSTICS via json.hpp

### DIFF
--- a/apache/client/include/lauth/json.hpp
+++ b/apache/client/include/lauth/json.hpp
@@ -1,0 +1,9 @@
+#ifndef __LAUTH_JSON_HPP__
+#define __LAUTH_JSON_HPP__
+
+#undef JSON_DIAGNOSTICS
+#define JSON_DIAGNOSTICS 1
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
+
+#endif // __LAUTH_JSON_HPP__

--- a/apache/client/include/lauth/json_conversions.hpp
+++ b/apache/client/include/lauth/json_conversions.hpp
@@ -1,15 +1,13 @@
 #ifndef __LAUTH_JSON_CONVERSIONS_HPP__
 #define __LAUTH_JSON_CONVERSIONS_HPP__
 
-#include <nlohmann/json.hpp>
+#include "lauth/json.hpp"
 
 #include "lauth/authorization_result.hpp"
 
-using json = nlohmann::json;
-
 namespace mlibrary::lauth {
-  void to_json(nlohmann::json& j, const AuthorizationResult& authz);
-  void from_json(const nlohmann::json& j, AuthorizationResult& authz);
+  void to_json(json& j, const AuthorizationResult& authz);
+  void from_json(const json& j, AuthorizationResult& authz);
 }
 
 #endif // __LAUTH_JSON_CONVERSIONS_HPP__

--- a/apache/client/src/lauth/api_client.cpp
+++ b/apache/client/src/lauth/api_client.cpp
@@ -2,11 +2,9 @@
 
 #include <sstream>
 #include <string>
-#include <nlohmann/json.hpp>
 
+#include "lauth/json.hpp"
 #include "lauth/json_conversions.hpp"
-
-using json = nlohmann::json;
 
 namespace mlibrary::lauth {
   AuthorizationResult ApiClient::authorize(Request req) {

--- a/apache/client/src/lauth/authorization_result.cpp
+++ b/apache/client/src/lauth/authorization_result.cpp
@@ -2,8 +2,7 @@
 
 #include <string>
 
-#include <nlohmann/json.hpp>
-
+#include "lauth/json.hpp"
 #include "lauth/json_conversions.hpp"
 
 using json = nlohmann::json;

--- a/apache/client/test/lauth/authorization_result_test.cpp
+++ b/apache/client/test/lauth/authorization_result_test.cpp
@@ -4,12 +4,11 @@
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
-#include <nlohmann/json.hpp>
 
+#include "lauth/json.hpp"
 #include "lauth/json_conversions.hpp"
 
 using namespace mlibrary::lauth;
-using json = nlohmann::json;
 
 TEST(AuthorizationResultTest, FromJson) {
   std::string stringBody = R"({"determination":"allowed"})";


### PR DESCRIPTION
Moves the various inclusions of the json library into our own small header, and enables diagnostics.
See https://json.nlohmann.me/api/macros/json_diagnostics/

Honestly the diagnostics could be on or off. Still worth it to combine these common includes.