### PR TITLE
Support finding institution member grants

### DIFF
--- a/lauth/app/repositories/grant_repo.rb
+++ b/lauth/app/repositories/grant_repo.rb
@@ -21,6 +21,31 @@ module Lauth
         rel.combine(:user, collection: :locations).to_a
       end
 
+      # FIXME: This is scratch code for getting institutions and memberships worked in.
+      #        The real implementation will be integrated into for_user_and_uri because we
+      #        don't differentiate by grant type when authorizing; we just have user + uri.
+      #        This is fully explicit (all joins and username filtered in the WHERE) and
+      #        fully eager (loading all of the associated entities), for the sake of demo
+      #        and discussion. It will likely use left joins or unions to find everything
+      #        while partitioning the complexity into the three types of grants. Since
+      #        loading the associated entities is done by IN clause on IDs, we are not
+      #        concerned with the ultimate result set having all of the columns and the
+      #        overhead of duplicates. The joins are really only to filter the grants.
+      def for_member_and_uri(username, uri)
+        ds = grants
+          .dataset
+          .join(collections.name.dataset, uniqueIdentifier: :coll)
+          .join(locations.name.dataset, coll: :uniqueIdentifier)
+          .join(institutions.name.dataset, uniqueIdentifier: grants[:inst])
+          .join(institution_memberships.name.dataset, inst: :uniqueIdentifier)
+          .join(users.name.dataset, userid: :userid)
+          .where(Sequel.ilike(uri, locations[:dlpsPath]))
+          .where(users[:userid] => username)
+
+        rel = grants.class.new(ds)
+        rel.combine(collections: :locations, institutions: {institution_memberships: :users}).to_a
+      end
+
       def for_uri(uri)
         ds = grants
           .dataset

--- a/lauth/lib/lauth/institution.rb
+++ b/lauth/lib/lauth/institution.rb
@@ -1,0 +1,4 @@
+module Lauth
+  class Institution < ROM::Struct
+  end
+end

--- a/lauth/lib/lauth/institution_membership.rb
+++ b/lauth/lib/lauth/institution_membership.rb
@@ -1,0 +1,4 @@
+module Lauth
+  class InstitutionMembership < ROM::Struct
+  end
+end

--- a/lauth/lib/lauth/persistence/relations/institution_memberships.rb
+++ b/lauth/lib/lauth/persistence/relations/institution_memberships.rb
@@ -1,13 +1,8 @@
 module Lauth
   module Persistence
     module Relations
-      class Grants < ROM::Relation[:sql]
-        schema(:aa_may_access, infer: true, as: :grants) do
-          # attribute :uniqueIdentifier, Types::Integer.default { AutoIncrement.id }
-          # attribute :userid, Types::String.default("userid".freeze)
-          # attribute :user_grp, Types::Integer.default(0)
-          # attribute :inst, Types::Integer.default(0)
-          # attribute :coll, Types::String.default("coll".freeze)
+      class InstitutionMemberships < ROM::Relation[:sql]
+        schema(:aa_is_member_of_inst, infer: true, as: :institution_memberships) do
           # attribute :lastModifiedTime, Types::Time.default { Time.now }
           attribute :lastModifiedBy, Types::String.default("root".freeze)
           # attribute :dlpsExpiryTime, Types::Time.default { Time.now }
@@ -15,7 +10,6 @@ module Lauth
 
           associations do
             belongs_to :user, foreign_key: :userid
-            belongs_to :collection, foreign_key: :coll
             belongs_to :institution, foreign_key: :inst
           end
         end

--- a/lauth/lib/lauth/persistence/relations/institutions.rb
+++ b/lauth/lib/lauth/persistence/relations/institutions.rb
@@ -1,0 +1,22 @@
+module Lauth
+  module Persistence
+    module Relations
+      class Institutions < ROM::Relation[:sql]
+        schema(:aa_inst, infer: true, as: :institutions) do
+          # attribute :lastModifiedTime, Types::Time.default { Time.now }
+          attribute :lastModifiedBy, Types::String.default("root".freeze)
+          # attribute :dlpsExpiryTime, Types::Time.default { Time.now }
+          attribute :dlpsDeleted, Types::String.default("f".freeze)
+
+          associations do
+            has_many :grants, foreign_key: :inst
+            has_many :institution_memberships, foreign_key: :inst
+          end
+        end
+
+        struct_namespace Lauth
+        auto_struct true
+      end
+    end
+  end
+end

--- a/lauth/spec/ops/authorize_spec.rb
+++ b/lauth/spec/ops/authorize_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Lauth::Ops::Authorize, type: :database do
   context "with an authorized user" do
     let!(:user) { Factory[:user, userid: "lauth-allowed"] }
     let!(:collection) { Factory[:collection, :restricted_by_username] }
-    let!(:grant) { Factory[:grant, user: user, collection: collection] }
+    let!(:grant) { Factory[:grant, :for_user, user: user, collection: collection] }
 
     it "allows access" do
       request = Lauth::Access::Request.new(

--- a/lauth/spec/repositories/grant_repo_spec.rb
+++ b/lauth/spec/repositories/grant_repo_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Lauth::Repositories::GrantRepo, type: :database do
   context "with a grant for one user to a collection restricted by username" do
     let!(:collection) { Factory[:collection, :restricted_by_username] }
     let!(:user) { Factory[:user, userid: "lauth-allowed"] }
-    let!(:grant) { Factory[:grant, user: user, collection: collection] }
+    let!(:grant) { Factory[:grant, :for_user, user: user, collection: collection] }
 
     # describe #for_uri
     it "finds the grant for a resource within the collection" do
@@ -49,6 +49,23 @@ RSpec.describe Lauth::Repositories::GrantRepo, type: :database do
 
       it "loads location" do
         expect(found_grant.collection.locations.first.dlpsPath).to eq "/restricted-by-username%"
+      end
+    end
+  end
+
+  context "when authorizing locations within a collection using identity-only authentication" do
+    context "for a member of an authorized institution" do
+      let!(:collection) { Factory[:collection, :restricted_by_username] }
+      let!(:institution) { Factory[:institution] }
+      let!(:user) { Factory[:user, userid: "lauth-inst-member"] }
+      let!(:membership) { Factory[:institution_membership, user: user, institution: institution] }
+      let!(:grant) { Factory[:grant, :for_institution, institution: institution, collection: collection] }
+
+      it "finds that member's grant" do
+        grant_ids = repo.for_member_and_uri("lauth-inst-member", "/restricted-by-username/")
+          .map(&:uniqueIdentifier)
+
+        expect(grant_ids).to contain_exactly(grant.uniqueIdentifier)
       end
     end
   end

--- a/lauth/spec/requests/authorized_spec.rb
+++ b/lauth/spec/requests/authorized_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "/authorized", type: [:request, :database] do
   context "with an authorized user" do
     let!(:user) { Factory[:user, userid: "lauth-allowed"] }
     let!(:collection) { Factory[:collection, :restricted_by_username] }
-    let!(:grant) { Factory[:grant, user: user, collection: collection] }
+    let!(:grant) { Factory[:grant, :for_user, user: user, collection: collection] }
 
     it do
       get "/authorized", {user: "lauth-allowed", uri: "/restricted-by-username/"}

--- a/lauth/spec/support/factories/grant.rb
+++ b/lauth/spec/support/factories/grant.rb
@@ -1,9 +1,16 @@
 Factory.define(:grant, struct_namespace: Lauth) do |f|
   f.sequence(:uniqueIdentifier) { |n| n }
-  f.association(:user)
   f.association(:collection)
   f.lastModifiedTime Time.now
   f.lastModifiedBy "root"
   f.dlpsExpiryTime Time.now
   f.dlpsDeleted "f"
+
+  f.trait(:for_user) do |t|
+    t.association(:user)
+  end
+
+  f.trait(:for_institution) do |t|
+    t.association(:institution)
+  end
 end

--- a/lauth/spec/support/factories/institution.rb
+++ b/lauth/spec/support/factories/institution.rb
@@ -1,0 +1,7 @@
+Factory.define(:institution, struct_namespace: Lauth) do |f|
+  f.sequence(:uniqueIdentifier) { |n| n }
+  f.sequence(:organizationName) { |n| "Institution #{n}" }
+  f.lastModifiedTime Time.now
+  f.lastModifiedBy "root"
+  f.dlpsDeleted "f"
+end

--- a/lauth/spec/support/factories/institution_membership.rb
+++ b/lauth/spec/support/factories/institution_membership.rb
@@ -1,0 +1,7 @@
+Factory.define(:institution_membership, struct_namespace: Lauth) do |f|
+  f.association(:user)
+  f.association(:institution)
+  f.lastModifiedTime Time.now
+  f.lastModifiedBy "root"
+  f.dlpsDeleted "f"
+end


### PR DESCRIPTION
This is not yet integrated into the action because we need to discuss the approach -- left joins, unions, or separate queries. This temporary repository method can be added to support that discussion without disrupting the existing for_user_and_uri.

- Add base case spec for an institutional member
- Adjust grant factory to have for_user and for_institution traits
- Add institution and institution_memberships relations and factories