### PR TITLE
Authorize group member by identity/username

### DIFF
--- a/lauth/app/repositories/grant_repo.rb
+++ b/lauth/app/repositories/grant_repo.rb
@@ -15,6 +15,7 @@ module Lauth
           .join(locations.name.dataset, coll: :uniqueIdentifier)
           .left_join(users.name.dataset, userid: grants[:userid])
           .left_join(institution_memberships.name.dataset, inst: grants[:inst])
+          .left_join(group_memberships.name.dataset, user_grp: grants[:user_grp])
           .where(Sequel.ilike(uri, locations[:dlpsPath]))
           .where(
             Sequel.|(
@@ -25,6 +26,10 @@ module Lauth
               Sequel.&(
                 Sequel.~(institution_memberships[:userid] => nil),
                 {institution_memberships[:userid] => username}
+              ),
+              Sequel.&(
+                Sequel.~(group_memberships[:userid] => nil),
+                {group_memberships[:userid] => username}
               )
             )
           )

--- a/lauth/lib/lauth/group.rb
+++ b/lauth/lib/lauth/group.rb
@@ -1,0 +1,4 @@
+module Lauth
+  class Group < ROM::Struct
+  end
+end

--- a/lauth/lib/lauth/persistence/relations/grants.rb
+++ b/lauth/lib/lauth/persistence/relations/grants.rb
@@ -17,6 +17,7 @@ module Lauth
             belongs_to :user, foreign_key: :userid
             belongs_to :collection, foreign_key: :coll
             belongs_to :institution, foreign_key: :inst
+            belongs_to :group, foreign_key: :user_grp
           end
         end
 

--- a/lauth/lib/lauth/persistence/relations/group_memberships.rb
+++ b/lauth/lib/lauth/persistence/relations/group_memberships.rb
@@ -1,15 +1,15 @@
 module Lauth
   module Persistence
     module Relations
-      class Institutions < ROM::Relation[:sql]
-        schema(:aa_inst, infer: true, as: :institutions) do
+      class GroupMemberships < ROM::Relation[:sql]
+        schema(:aa_is_member_of_grp, infer: true, as: :group_memberships) do
           # attribute :lastModifiedTime, Types::Time.default { Time.now }
           attribute :lastModifiedBy, Types::String.default("root".freeze)
           attribute :dlpsDeleted, Types::String.default("f".freeze)
 
           associations do
-            has_many :grants, foreign_key: :inst
-            has_many :institution_memberships, foreign_key: :inst
+            belongs_to :user, foreign_key: :userid
+            belongs_to :group, foreign_key: :user_grp
           end
         end
 

--- a/lauth/lib/lauth/persistence/relations/groups.rb
+++ b/lauth/lib/lauth/persistence/relations/groups.rb
@@ -1,15 +1,16 @@
 module Lauth
   module Persistence
     module Relations
-      class Institutions < ROM::Relation[:sql]
-        schema(:aa_inst, infer: true, as: :institutions) do
+      class Groups < ROM::Relation[:sql]
+        schema(:aa_user_grp, infer: true, as: :groups) do
           # attribute :lastModifiedTime, Types::Time.default { Time.now }
+          # attribute :manager, Types::Integer.default(0)
           attribute :lastModifiedBy, Types::String.default("root".freeze)
           attribute :dlpsDeleted, Types::String.default("f".freeze)
 
           associations do
-            has_many :grants, foreign_key: :inst
-            has_many :institution_memberships, foreign_key: :inst
+            has_many :grants, foreign_key: :user_grp
+            has_many :group_memberships, foreign_key: :user_grp
           end
         end
 

--- a/lauth/spec/requests/authorized_spec.rb
+++ b/lauth/spec/requests/authorized_spec.rb
@@ -21,4 +21,22 @@ RSpec.describe "/authorized", type: [:request, :database] do
       expect(body).to eq({determination: "allowed"})
     end
   end
+
+  context "with an authorized group" do
+    let!(:user) { Factory[:user, userid: "lauth-group-member"] }
+    let!(:collection) { Factory[:collection, :restricted_by_username] }
+    let!(:group) {
+      Factory[:group]
+      relations.groups.last
+    }
+    let!(:group_membership) { Factory[:group_membership, group: group, user: user] }
+    let!(:grant) { Factory[:grant, :for_group, group: group, collection: collection] }
+
+    it do
+      get "/authorized", {user: "lauth-group-member", uri: "/restricted-by-username/"}
+
+      body = JSON.parse(last_response.body, symbolize_names: true)
+      expect(body).to eq({determination: "allowed"})
+    end
+  end
 end

--- a/lauth/spec/support/factories/grant.rb
+++ b/lauth/spec/support/factories/grant.rb
@@ -13,4 +13,8 @@ Factory.define(:grant, struct_namespace: Lauth) do |f|
   f.trait(:for_institution) do |t|
     t.association(:institution)
   end
+
+  f.trait(:for_group) do |t|
+    t.association(:group)
+  end
 end

--- a/lauth/spec/support/factories/group.rb
+++ b/lauth/spec/support/factories/group.rb
@@ -1,0 +1,8 @@
+Factory.define(:group, struct_namespace: Lauth) do |f|
+  f.sequence(:uniqueIdentifier) { |n| n }
+  f.sequence(:commonName) { |n| "Group #{n}" }
+  f.manager 0
+  f.lastModifiedTime Time.now
+  f.lastModifiedBy "root"
+  f.dlpsDeleted "f"
+end

--- a/lauth/spec/support/factories/group_membership.rb
+++ b/lauth/spec/support/factories/group_membership.rb
@@ -1,0 +1,7 @@
+Factory.define(:group_membership, struct_namespace: Lauth) do |f|
+  f.association(:user)
+  f.association(:group)
+  f.lastModifiedTime Time.now
+  f.lastModifiedBy "root"
+  f.dlpsDeleted "f"
+end

--- a/lauth/spec/support/requests.rb
+++ b/lauth/spec/support/requests.rb
@@ -6,7 +6,13 @@ RSpec.shared_context "Rack::Test" do
   let(:app) { Hanami.app }
 end
 
+RSpec.shared_context "Lauth::Persistence" do
+  let(:rom) { Hanami.app["persistence.rom"] }
+  let(:relations) { rom.relations }
+end
+
 RSpec.configure do |config|
   config.include Rack::Test::Methods, type: :request
   config.include_context "Rack::Test", type: :request
+  config.include_context "Lauth::Persistence", type: :database
 end


### PR DESCRIPTION
This rounds out our primary three cases for authorizing access with authentication by username. There are sub-scenarios yet to come (with deny/deleted flags, etc.), but we are ready to move on to network/ip-based authentication.

This change proved challenging to develop because of an expectation in the ROM/Factory/Sequel/mysql2 layering, where Sequel::Dataset#insert will return the last inserted ID by default. Then, ROM::Relation looks to query for the newly-inserted tuple. However, when the primary key is not an auto-incrementing integer, the insert returns nil, which means that the relation comes back nil. This means that we have to supply an identifier and, after creating the row, query for it explicitly.

The group table is the only integer-keyed table without auto-increment, so this should be the only place we run into this.