### PR TITLE
Add network-only scenarios test and implementation to system, cpp, ruby 

### DIFF
--- a/apache/conf/lauth.conf
+++ b/apache/conf/lauth.conf
@@ -4,3 +4,4 @@ SetHandler lauth
 </Location>
 
 RemoteIPHeader X-Client-IP
+RemoteIPInternalProxy 192.0.0.0/8

--- a/apache/conf/lauth.conf
+++ b/apache/conf/lauth.conf
@@ -4,4 +4,5 @@ SetHandler lauth
 </Location>
 
 RemoteIPHeader X-Client-IP
-RemoteIPInternalProxy 192.0.0.0/8
+RemoteIPInternalProxy 0.0.0.0/1
+RemoteIPInternalProxy 128.0.0.0/1

--- a/apache/conf/test-site.conf
+++ b/apache/conf/test-site.conf
@@ -19,6 +19,17 @@
       Require lauth
     </RequireAll>
   </Location>
+
+  <Location "/restricted-by-network/">
+    AuthType Basic
+    AuthName "Restricted Resource"
+    AuthUserFile /lauth/test-site/htpasswd
+    AuthzSendForbiddenOnFailure On
+    <RequireAll>
+      Require valid-user
+      Require lauth
+    </RequireAll>
+  </Location>
 </VirtualHost>
 
 # <VirtualHost *:443>

--- a/db/network.sql
+++ b/db/network.sql
@@ -1,0 +1,63 @@
+-- Create an institution within the larger institution
+INSERT INTO aa_inst VALUES(
+  NULL,
+  'Lauth Law Enclave', NULL,
+  CURRENT_TIMESTAMP, 'root', -- modified info
+  'f' -- deleted
+);
+SET @enclave_inst_id = LAST_INSERT_ID();
+
+-- We use the existing inst as the larger university network.
+SET @big_inst_id = (
+  SELECT uniqueIdentifier
+  FROM aa_inst
+  WHERE organizationName = 'University of Lauth, Testing'
+);
+
+-- Collection for most network scenarios
+INSERT INTO aa_coll VALUES(
+  'lauth-by-client-ip', -- uniqueIdentifier
+  'lauth-by-client-ip', -- commonName
+  'auth system testing: network authentication',
+  'lauth-test', -- dlpsClass
+  'none', -- dlpsSource (unused)
+  'ip', -- dlpsAuthenMethod
+  'n', -- dlpsAuthzType
+  'f', -- dlpsPartlyPublic
+  0, -- manager
+  CURRENT_TIMESTAMP, 'root', -- modified info
+  'f' -- deleted
+);
+
+INSERT INTO aa_coll_obj VALUES(
+  'www.lauth.local', -- server hostname, not vhost
+  '/lauth/test-site/web/restricted-by-network%', -- dlpsPath
+  'lauth-by-client-ip', -- coll.uniqueIdentifier
+  CURRENT_TIMESTAMP, 'root', -- modified info
+  'f' -- deleted
+);
+
+INSERT INTO aa_may_access VALUES(
+  NULL, -- uniqueIdentifier
+  NULL, -- userid
+  NULL, -- user_grp
+  @big_inst_id, -- inst
+  'lauth-by-client-ip', -- coll
+  CURRENT_TIMESTAMP,
+  'root',
+  NULL,
+  'f'
+);
+
+------A full /24 allowed campus network-------
+-- allow campus 10.1.16.0/24 (255 - 0)
+INSERT INTO aa_network --
+VALUES (
+  NULL, NULL,
+  '10.1.16.0/24', 167841792, 167842047,
+  'allow', NULL, @big_inst_id,
+  CURRENT_TIMESTAMP, 'root', 'f'
+);
+
+-- keep this range free of rules!
+-- null 10.1.8.0/24 (255)

--- a/db/network.sql
+++ b/db/network.sql
@@ -49,6 +49,18 @@ INSERT INTO aa_may_access VALUES(
   'f'
 );
 
+INSERT INTO aa_may_access VALUES(
+  NULL, -- uniqueIdentifier
+  NULL, -- userid
+  NULL, -- user_grp
+  @enclave_inst_id, -- inst
+  'lauth-by-client-ip', -- coll
+  CURRENT_TIMESTAMP,
+  'root',
+  NULL,
+  'f'
+);
+
 ------A full /24 allowed campus network-------
 -- allow campus 10.1.16.0/24 (255 - 0)
 INSERT INTO aa_network --
@@ -61,3 +73,59 @@ VALUES (
 
 -- keep this range free of rules!
 -- null 10.1.8.0/24 (255)
+
+----Campus net with a single blocked ip and an allowed enclave----
+-- allow campus 10.1.6.0/24 (255)
+-- deny one ip 10.1.6.2/32 (1)
+-- allow enclave 10.1.6.8/29 (8)
+INSERT INTO aa_network -- campus network
+VALUES (
+  NULL, NULL,
+  '10.1.6.0/24', 167839232, 167839487,
+  'allow', NULL, @big_inst_id,
+  CURRENT_TIMESTAMP, 'root', 'f'
+);
+INSERT INTO aa_network -- blocked ip
+VALUES (
+  NULL, NULL,
+  '10.1.6.2/32', 167839234, 167839234,
+  'deny', NULL, @big_inst_id,
+  CURRENT_TIMESTAMP, 'root', 'f'
+);
+INSERT INTO aa_network -- allowed enclave
+VALUES (
+  NULL, NULL,
+  '10.1.6.8/29', 167839240, 167839247,
+  'allow', NULL, @enclave_inst_id,
+  CURRENT_TIMESTAMP, 'root', 'f'
+);
+
+----An allowed enclave within a denied campus-----
+-- deny campus 10.1.7.0/24 (255 - 8)
+-- allow enclave 10.1.7.8/29 (-8)
+INSERT INTO aa_network -- campus network, denied
+VALUES (
+  NULL, NULL,
+  '10.1.7.0/24', 167839488, 167839743,
+  'deny', NULL, @big_inst_id,
+  CURRENT_TIMESTAMP, 'root', 'f'
+);
+INSERT INTO aa_network -- allowed enclave
+VALUES (
+  NULL, NULL,
+  '10.1.7.8/29', 167839496, 167839503,
+  'allow', NULL, @enclave_inst_id,
+  CURRENT_TIMESTAMP, 'root', 'f'
+);
+
+
+
+------A full /24 denied campus network-------
+-- deny campus 10.1.17.0/24 (255 - 0)
+INSERT INTO aa_network
+VALUES (
+  NULL, NULL,
+  '10.1.17.0/24', 167842048, 167842303,
+  'deny', NULL, @big_inst_id,
+  CURRENT_TIMESTAMP, 'root', 'f'
+);

--- a/db/setup.sh
+++ b/db/setup.sh
@@ -42,4 +42,5 @@ if [[ $all == "true" ]]; then
   mariadb --user=$user --host=$host --port=$port --password=$password $database < "$directory/root.sql"
   mariadb --user=$user --host=$host --port=$port --password=$password $database < "$directory/keys.sql"
   mariadb --user=$user --host=$host --port=$port --password=$password $database < "$directory/test-fixture.sql"
+  mariadb --user=$user --host=$host --port=$port --password=$password $database < "$directory/network.sql"
 fi

--- a/db/test-fixture.sql
+++ b/db/test-fixture.sql
@@ -47,10 +47,6 @@ INSERT INTO aa_may_access VALUES(
   NULL, NULL, @test_inst_id, 'lauth-by-username', CURRENT_TIMESTAMP, 'root', NULL, 'f'
 );
 
------- TODO: Discuss network ranges
--- INSERT INTO aa_network VALUES(
---   NULL, NULL, '10.1.1.1/24', 167837953, 167838207, 'allow', NULL, @test_inst_id, CURRENT_TIMESTAMP, 'root', 'f'
--- );
 
 INSERT INTO aa_user VALUES(
   'lauth-allowed',NULL,'Lauth',NULL,'Tester-Allowed','lauth-allowed@umich.edu',

--- a/lauth/app/actions/authorize.rb
+++ b/lauth/app/actions/authorize.rb
@@ -7,7 +7,9 @@ module Lauth
 
         result = Lauth::Ops::Authorize.new(
           request: Lauth::Access::Request.new(
-            user: request.params[:user], uri: request.params[:uri]
+            user: request.params[:user],
+            uri: request.params[:uri],
+            client_ip: request.params[:ip]
           )
         ).call
 

--- a/lauth/app/repositories/grant_repo.rb
+++ b/lauth/app/repositories/grant_repo.rb
@@ -15,7 +15,7 @@ module Lauth
           .where { dlpsAddressStart <= ip }
           .where { dlpsAddressEnd >= ip }
           .select_append(Sequel.as(Sequel.expr { dlpsAddressEnd - dlpsAddressStart }, :block_size))
-          .order(Sequel.desc(:block_size)).limit(1)
+          .order(Sequel.asc(:block_size)).limit(1)
 
         ds = grants
           .dataset

--- a/lauth/app/repositories/grant_repo.rb
+++ b/lauth/app/repositories/grant_repo.rb
@@ -8,7 +8,15 @@ module Lauth
         grants.where(uniqueIdentifier: id).one
       end
 
-      def for_user_and_uri(username, uri)
+      def for(username:, uri:, client_ip: nil)
+        ip = client_ip ? IPAddr.new(client_ip).to_i : nil
+        smallest_network = networks
+          .dataset
+          .where { dlpsAddressStart <= ip }
+          .where { dlpsAddressEnd >= ip }
+          .select_append(Sequel.as(Sequel.expr { dlpsAddressEnd - dlpsAddressStart }, :block_size))
+          .order(Sequel.desc(:block_size)).limit(1)
+
         ds = grants
           .dataset
           .join(collections.name.dataset, uniqueIdentifier: :coll)
@@ -16,6 +24,7 @@ module Lauth
           .left_join(users.name.dataset, userid: grants[:userid])
           .left_join(institution_memberships.name.dataset, inst: grants[:inst])
           .left_join(group_memberships.name.dataset, user_grp: grants[:user_grp])
+          .left_join(Sequel.as(smallest_network, :smallest), inst: grants[:inst])
           .where(Sequel.ilike(uri, locations[:dlpsPath]))
           .where(
             Sequel.|(
@@ -30,6 +39,10 @@ module Lauth
               Sequel.&(
                 Sequel.~(group_memberships[:userid] => nil),
                 {group_memberships[:userid] => username}
+              ),
+              Sequel.&(
+                Sequel.~(Sequel[:smallest][:inst] => nil),
+                {Sequel[:smallest][:dlpsAccessSwitch] => "allow"}
               )
             )
           )

--- a/lauth/lib/lauth/network.rb
+++ b/lauth/lib/lauth/network.rb
@@ -1,0 +1,4 @@
+module Lauth
+  class Network < ROM::Struct
+  end
+end

--- a/lauth/lib/lauth/ops/authorize.rb
+++ b/lauth/lib/lauth/ops/authorize.rb
@@ -13,7 +13,12 @@ module Lauth
       end
 
       def call
-        determination = if grant_repo.for_user_and_uri(request.user, request.uri).any?
+        relevant_grants = grant_repo.for(
+          username: request.user,
+          uri: request.uri,
+          client_ip: request.client_ip
+        )
+        determination = if relevant_grants.any?
           "allowed"
         else
           "denied"

--- a/lauth/lib/lauth/persistence/relations/networks.rb
+++ b/lauth/lib/lauth/persistence/relations/networks.rb
@@ -1,0 +1,35 @@
+module Lauth
+  module Persistence
+    module Relations
+      # +------------------+------------------+------+-----+---------+----------------+
+      # | Field            | Type             | Null | Key | Default | Extra          |
+      # +------------------+------------------+------+-----+---------+----------------+
+      # | uniqueIdentifier | int(11)          | NO   | PRI | NULL    | auto_increment |
+      # | dlpsDNSName      | varchar(128)     | YES  |     | NULL    |                |
+      # | dlpsCIDRAddress  | varchar(18)      | YES  |     | NULL    |                |
+      # | dlpsAddressStart | int(10) unsigned | YES  | MUL | NULL    |                |
+      # | dlpsAddressEnd   | int(10) unsigned | YES  | MUL | NULL    |                |
+      # | dlpsAccessSwitch | varchar(5)       | NO   |     | NULL    |                |
+      # | coll             | varchar(32)      | YES  | MUL | NULL    |                |
+      # | inst             | int(11)          | YES  | MUL | NULL    |                |
+      # | lastModifiedTime | timestamp        | NO   |     | NULL    |                |
+      # | lastModifiedBy   | varchar(64)      | NO   | MUL | NULL    |                |
+      # | dlpsDeleted      | char(1)          | NO   |     | NULL    |                |
+      # +------------------+------------------+------+-----+---------+----------------+
+      class Networks < ROM::Relation[:sql]
+        schema(:aa_network, infer: true, as: :networks) do
+          attribute :lastModifiedBy, Types::String.default("root".freeze)
+          attribute :dlpsDeleted, Types::String.default("f".freeze)
+
+          associations do
+            belongs_to :collection, foreign_key: :coll
+            belongs_to :institution, foreign_key: :inst
+          end
+        end
+
+        struct_namespace Lauth
+        auto_struct true
+      end
+    end
+  end
+end

--- a/lauth/spec/repositories/grant_repo_spec.rb
+++ b/lauth/spec/repositories/grant_repo_spec.rb
@@ -3,6 +3,34 @@
 RSpec.describe Lauth::Repositories::GrantRepo, type: :database do
   subject(:repo) { Lauth::Repositories::GrantRepo.new }
 
+  def cidr_range(x)
+    (32 - Math.log2((x.to_range.last.to_i - x.to_range.first.to_i) + 1)).to_i
+  end
+
+  def build_network(cidr, institution)
+    ip_range = IPAddr.new(cidr)
+    Factory[
+      :network,
+      :for_institution,
+      institution: institution,
+      dlpsCIDRAddress: [ip_range, cidr_range(ip_range).to_s].join("/"),
+      dlpsAddressStart: ip_range.to_range.first.to_i,
+      dlpsAddressEnd: ip_range.to_range.last.to_i,
+    ]
+  end
+
+  context "when authorizing locations within a collection using only client_ip" do
+    context "within the network" do
+      let!(:institution) { Factory[:institution] }
+      let!(:network) { build_network("10.1.16.0/24", institution) }
+      let!(:collection) { Factory[:collection, :restricted_by_client_ip] }
+      let!(:grant) { Factory[:grant, :for_institution, institution: institution, collection: collection] }
+      it "finds the network grant" do
+        repo.for(username: "", uri: "/restricted-by-client-ip/", client_ip: "10.1.16.1")
+      end
+    end
+  end
+
   context "when authorizing locations within a collection using identity-only authentication" do
     context "with an authorized individual" do
       let!(:collection) { Factory[:collection, :restricted_by_username] }
@@ -10,19 +38,20 @@ RSpec.describe Lauth::Repositories::GrantRepo, type: :database do
       let!(:grant) { Factory[:grant, :for_user, user: user, collection: collection] }
 
       it "finds the grant for authorized individual and location within the collection" do
-        grants = repo.for_user_and_uri("lauth-allowed", "/restricted-by-username/")
+        grants = repo.for(username: "lauth-allowed", uri: "/restricted-by-username/")
 
         expect(grants.first.uniqueIdentifier).to eq grant.uniqueIdentifier
       end
 
       it "finds no grant for unauthorized individual and location within the collection" do
-        grants = repo.for_user_and_uri("lauth-denied", "/restricted-by-username/")
+        grants = repo.for(username: "lauth-denied", uri: "/restricted-by-username/")
 
         expect(grants).to eq []
       end
 
+      # TODO: extract this
       describe "grant association loading" do
-        subject(:found_grant) { repo.for_user_and_uri("lauth-allowed", "/restricted-by-username/").first }
+        subject(:found_grant) { repo.for(username: "lauth-allowed", uri: "/restricted-by-username/").first }
 
         it "loads user" do
           expect(found_grant.user.userid).to eq grant.user.userid
@@ -46,26 +75,26 @@ RSpec.describe Lauth::Repositories::GrantRepo, type: :database do
       let!(:grant) { Factory[:grant, :for_institution, institution: institution, collection: collection] }
 
       it "finds that member's grant" do
-        grant_ids = repo.for_user_and_uri("lauth-inst-member", "/restricted-by-username/")
+        grant_ids = repo.for(username: "lauth-inst-member", uri: "/restricted-by-username/")
           .map(&:uniqueIdentifier)
 
         expect(grant_ids).to contain_exactly(grant.uniqueIdentifier)
       end
 
       it "finds nothing for a nonmember" do
-        grants = repo.for_user_and_uri("lauth-denied", "/restricted-by-username/")
+        grants = repo.for(username: "lauth-denied", uri: "/restricted-by-username/")
 
         expect(grants).to be_empty
       end
 
       it "finds nothing for an empty user" do
-        grants = repo.for_user_and_uri("", "/restricted-by-username/")
+        grants = repo.for(username: "", uri: "/restricted-by-username/")
 
         expect(grants).to be_empty
       end
 
       it "finds nothing for a nil user" do
-        grants = repo.for_user_and_uri(nil, "/restricted-by-username/")
+        grants = repo.for(username: nil, uri: "/restricted-by-username/")
 
         expect(grants).to be_empty
       end
@@ -82,26 +111,26 @@ RSpec.describe Lauth::Repositories::GrantRepo, type: :database do
       let!(:grant) { Factory[:grant, :for_group, group: group, collection: collection] }
 
       it "finds that member's grant" do
-        grant_ids = repo.for_user_and_uri("lauth-group-member", "/restricted-by-username/")
+        grant_ids = repo.for(username: "lauth-group-member", uri: "/restricted-by-username/")
           .map(&:uniqueIdentifier)
 
         expect(grant_ids).to contain_exactly(grant.uniqueIdentifier)
       end
 
       it "finds nothing for a nonmember" do
-        grants = repo.for_user_and_uri("lauth-denied", "/restricted-by-username/")
+        grants = repo.for(username: "lauth-denied", uri: "/restricted-by-username/")
 
         expect(grants).to be_empty
       end
 
       it "finds nothing for an empty user" do
-        grants = repo.for_user_and_uri("", "/restricted-by-username/")
+        grants = repo.for(username: "", uri: "/restricted-by-username/")
 
         expect(grants).to be_empty
       end
 
       it "finds nothing for a nil user" do
-        grants = repo.for_user_and_uri(nil, "/restricted-by-username/")
+        grants = repo.for(username: nil, uri: "/restricted-by-username/")
 
         expect(grants).to be_empty
       end

--- a/lauth/spec/repositories/grant_repo_spec.rb
+++ b/lauth/spec/repositories/grant_repo_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Lauth::Repositories::GrantRepo, type: :database do
   # Requires 'institution' be set in a let block.
   # @param access [String] Either 'allow' or 'deny'
   # @param cidr [String] A IPv4 CIDR range.
-  def build_network(access, cidr)
+  def create_network(access, cidr)
     ip_range = IPAddr.new(cidr)
     Factory[
       :network, :for_institution, institution: institution,
@@ -23,8 +23,8 @@ RSpec.describe Lauth::Repositories::GrantRepo, type: :database do
     let!(:collection) { Factory[:collection, :restricted_by_client_ip] }
     let!(:grant) { Factory[:grant, :for_institution, institution: institution, collection: collection] }
     context "(allow,deny) given a denied enclave within an allowed network" do
-      let!(:network) { build_network("allow", "10.1.6.0/24") }
-      let!(:enclave) { build_network("deny", "10.1.6.2/31") }
+      let!(:network) { create_network("allow", "10.1.6.0/24") }
+      let!(:enclave) { create_network("deny", "10.1.6.2/31") }
       it "finds no grant for a client_ip within the denied enclave" do
         grants = repo.for(username: "", uri: "/restricted-by-client-ip/", client_ip: "10.1.6.3")
 
@@ -32,8 +32,8 @@ RSpec.describe Lauth::Repositories::GrantRepo, type: :database do
       end
     end
     context "(deny,allow) given an allowed enclave within a denied network" do
-      let!(:network) { build_network("deny", "10.1.7.0/24") }
-      let!(:enclave) { build_network("allow", "10.1.7.8/29") }
+      let!(:network) { create_network("deny", "10.1.7.0/24") }
+      let!(:enclave) { create_network("allow", "10.1.7.8/29") }
       it "finds the grant for a client_ip within the allowed enclave" do
         grants = repo.for(username: "", uri: "/restricted-by-client-ip/", client_ip: "10.1.7.14")
 

--- a/lauth/spec/requests/authorized_client_ip_spec.rb
+++ b/lauth/spec/requests/authorized_client_ip_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "/authorized by client-ip", type: [:request, :database] do
   # @param access [String] Either 'allow' or 'deny'
   # @param cidr [String] A IPv4 CIDR range. We attempt to mirror those ranges that
   #   are in db/network.sql for clarity.
-  def build_network(access, cidr)
+  def create_network(access, cidr)
     Factory[
       :network, :for_institution, institution: institution,
       dlpsAccessSwitch: access, dlpsCIDRAddress: cidr
@@ -24,7 +24,7 @@ RSpec.describe "/authorized by client-ip", type: [:request, :database] do
   let!(:grant) { Factory[:grant, :for_institution, institution: institution, collection: collection] }
 
   context "(allow>none) given an allowed network only" do
-    let!(:network) { build_network("allow", "10.1.16.0/24") }
+    let!(:network) { create_network("allow", "10.1.16.0/24") }
 
     it "is allowed within the network" do
       expect(request_from("10.1.16.2")).to eq({determination: "allowed"})
@@ -36,8 +36,8 @@ RSpec.describe "/authorized by client-ip", type: [:request, :database] do
   end
 
   context "(allow>allow) given an allowed enclave within an allowed network" do
-    let!(:network) { build_network("allow", "10.1.6.0/24") }
-    let!(:enclave) { build_network("allow", "10.1.6.8/29") }
+    let!(:network) { create_network("allow", "10.1.6.0/24") }
+    let!(:enclave) { create_network("allow", "10.1.6.8/29") }
     it "is allowed within the enclave" do
       expect(request_from("10.1.6.9")).to eq({determination: "allowed"})
     end
@@ -47,8 +47,8 @@ RSpec.describe "/authorized by client-ip", type: [:request, :database] do
   end
 
   context "(allow>deny) given a denied enclave within an allowed network" do
-    let!(:network) { build_network("allow", "10.1.6.0/24") }
-    let!(:enclave) { build_network("deny", "10.1.6.2/32") }
+    let!(:network) { create_network("allow", "10.1.6.0/24") }
+    let!(:enclave) { create_network("deny", "10.1.6.2/32") }
     it "is denied within the enclave" do
       expect(request_from("10.1.6.2")).to eq({determination: "denied"})
     end
@@ -58,8 +58,8 @@ RSpec.describe "/authorized by client-ip", type: [:request, :database] do
   end
 
   context "(deny>allow) given an allowed enclave within a denied network" do
-    let!(:network) { build_network("deny", "10.1.7.0/24") }
-    let!(:enclave) { build_network("allow", "10.1.7.8/29") }
+    let!(:network) { create_network("deny", "10.1.7.0/24") }
+    let!(:enclave) { create_network("allow", "10.1.7.8/29") }
     it "is allowed within the enclave" do
       expect(request_from("10.1.7.14")).to eq({determination: "allowed"})
     end
@@ -69,8 +69,8 @@ RSpec.describe "/authorized by client-ip", type: [:request, :database] do
   end
 
   context "(deny>deny) given a denied enclave within a denied network" do
-    let!(:network) { build_network("deny", "10.1.17.0/24") }
-    let!(:enclave) { build_network("deny", "10.1.17.8/29") }
+    let!(:network) { create_network("deny", "10.1.17.0/24") }
+    let!(:enclave) { create_network("deny", "10.1.17.8/29") }
     it "is denied within the enclave" do
       expect(request_from("10.1.17.12")).to eq({determination: "denied"})
     end
@@ -80,7 +80,7 @@ RSpec.describe "/authorized by client-ip", type: [:request, :database] do
   end
 
   context "(deny>none) given a denied network only" do
-    let!(:network) { build_network("deny", "10.1.17.0/24") }
+    let!(:network) { create_network("deny", "10.1.17.0/24") }
     it "is denied within the network" do
       expect(request_from("10.1.17.2")).to eq({determination: "denied"})
     end

--- a/lauth/spec/requests/authorized_client_ip_spec.rb
+++ b/lauth/spec/requests/authorized_client_ip_spec.rb
@@ -1,0 +1,88 @@
+RSpec.describe "/authorized by client-ip", type: [:request, :database] do
+  # Convenience for building networks.
+  # Requires 'institution' be set in a let block.
+  # @param access [String] Either 'allow' or 'deny'
+  # @param cidr [String] A IPv4 CIDR range. We attempt to mirror those ranges that
+  #   are in db/network.sql for clarity.
+  def build_network(access, cidr)
+    Factory[
+      :network, :for_institution, institution: institution,
+      dlpsAccessSwitch: access, dlpsCIDRAddress: cidr
+    ]
+  end
+
+  # Request the location from the provided ip address
+  # @param ip [String]
+  # @return [Hash] the response body after json parsing
+  def request_from(ip)
+    get "/authorized", {user: "", uri: "/restricted-by-client-ip", ip: ip}
+    JSON.parse(last_response.body, symbolize_names: true)
+  end
+
+  let!(:institution) { Factory[:institution] }
+  let!(:collection) { Factory[:collection, :restricted_by_client_ip] }
+  let!(:grant) { Factory[:grant, :for_institution, institution: institution, collection: collection] }
+
+  context "(allow,null) given an allowed network only" do
+    let!(:network) { build_network("allow", "10.1.16.0/24") }
+
+    it "is allowed within the network" do
+      expect(request_from("10.1.16.2")).to eq({determination: "allowed"})
+    end
+
+    it "is denied outside the network" do
+      expect(request_from("10.1.17.1")).to eq({determination: "denied"})
+    end
+  end
+
+  context "(allow,allow) given an allowed enclave within an allowed network" do
+    let!(:network) { build_network("allow", "10.1.6.0/24") }
+    let!(:enclave) { build_network("allow", "10.1.6.8/29") }
+    it "is allowed within the enclave" do
+      expect(request_from("10.1.6.31")).to eq({determination: "allowed"})
+    end
+    it "is allowed outside the enclave" do
+      expect(request_from("10.1.6.9")).to eq({determination: "allowed"})
+    end
+  end
+
+  context "(allow,deny) given a denied enclave within an allowed network" do
+    let!(:network) { build_network("allow", "10.1.6.0/24") }
+    let!(:enclave) { build_network("deny", "10.1.6.2/32") }
+    it "is denied within the enclave" do
+      expect(request_from("10.1.6.2")).to eq({determination: "denied"})
+    end
+    it "is allowed outside the enclave" do
+      expect(request_from("10.1.6.44")).to eq({determination: "allowed"})
+    end
+  end
+
+  context "(deny,allow) given an allowed enclave within a denied network" do
+    let!(:network) { build_network("deny", "10.1.7.0/24") }
+    let!(:enclave) { build_network("allow", "10.1.7.8/29") }
+    it "is allowed within the enclave" do
+      expect(request_from("10.1.7.14")).to eq({determination: "allowed"})
+    end
+    it "is denied outside the enclave" do
+      expect(request_from("10.1.7.63")).to eq({determination: "denied"})
+    end
+  end
+
+  context "(deny,deny) given a denied enclave within a denied network" do
+    let!(:network) { build_network("deny", "10.1.17.0/24") }
+    let!(:enclave) { build_network("deny", "10.1.17.8/29") }
+    it "is denied within the enclave" do
+      expect(request_from("10.1.17.12")).to eq({determination: "denied"})
+    end
+    it "is denied outside the enclave" do
+      expect(request_from("10.1.17.63")).to eq({determination: "denied"})
+    end
+  end
+
+  context "(deny,null) given a denied network only" do
+    let!(:network) { build_network("deny", "10.1.17.0/24") }
+    it "is denied within the network" do
+      expect(request_from("10.1.17.2")).to eq({determination: "denied"})
+    end
+  end
+end

--- a/lauth/spec/requests/authorized_client_ip_spec.rb
+++ b/lauth/spec/requests/authorized_client_ip_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "/authorized by client-ip", type: [:request, :database] do
   let!(:collection) { Factory[:collection, :restricted_by_client_ip] }
   let!(:grant) { Factory[:grant, :for_institution, institution: institution, collection: collection] }
 
-  context "(allow,null) given an allowed network only" do
+  context "(allow>none) given an allowed network only" do
     let!(:network) { build_network("allow", "10.1.16.0/24") }
 
     it "is allowed within the network" do
@@ -35,18 +35,18 @@ RSpec.describe "/authorized by client-ip", type: [:request, :database] do
     end
   end
 
-  context "(allow,allow) given an allowed enclave within an allowed network" do
+  context "(allow>allow) given an allowed enclave within an allowed network" do
     let!(:network) { build_network("allow", "10.1.6.0/24") }
     let!(:enclave) { build_network("allow", "10.1.6.8/29") }
     it "is allowed within the enclave" do
-      expect(request_from("10.1.6.31")).to eq({determination: "allowed"})
+      expect(request_from("10.1.6.9")).to eq({determination: "allowed"})
     end
     it "is allowed outside the enclave" do
-      expect(request_from("10.1.6.9")).to eq({determination: "allowed"})
+      expect(request_from("10.1.6.7")).to eq({determination: "allowed"})
     end
   end
 
-  context "(allow,deny) given a denied enclave within an allowed network" do
+  context "(allow>deny) given a denied enclave within an allowed network" do
     let!(:network) { build_network("allow", "10.1.6.0/24") }
     let!(:enclave) { build_network("deny", "10.1.6.2/32") }
     it "is denied within the enclave" do
@@ -57,7 +57,7 @@ RSpec.describe "/authorized by client-ip", type: [:request, :database] do
     end
   end
 
-  context "(deny,allow) given an allowed enclave within a denied network" do
+  context "(deny>allow) given an allowed enclave within a denied network" do
     let!(:network) { build_network("deny", "10.1.7.0/24") }
     let!(:enclave) { build_network("allow", "10.1.7.8/29") }
     it "is allowed within the enclave" do
@@ -68,7 +68,7 @@ RSpec.describe "/authorized by client-ip", type: [:request, :database] do
     end
   end
 
-  context "(deny,deny) given a denied enclave within a denied network" do
+  context "(deny>deny) given a denied enclave within a denied network" do
     let!(:network) { build_network("deny", "10.1.17.0/24") }
     let!(:enclave) { build_network("deny", "10.1.17.8/29") }
     it "is denied within the enclave" do
@@ -79,7 +79,7 @@ RSpec.describe "/authorized by client-ip", type: [:request, :database] do
     end
   end
 
-  context "(deny,null) given a denied network only" do
+  context "(deny>none) given a denied network only" do
     let!(:network) { build_network("deny", "10.1.17.0/24") }
     it "is denied within the network" do
       expect(request_from("10.1.17.2")).to eq({determination: "denied"})

--- a/lauth/spec/requests/authorized_spec.rb
+++ b/lauth/spec/requests/authorized_spec.rb
@@ -1,5 +1,3 @@
-require "ipaddr"
-
 RSpec.describe "/authorized", type: [:request, :database] do
   # known resource, authorized user
   # unknown resource, authorized user
@@ -55,7 +53,7 @@ RSpec.describe "/authorized", type: [:request, :database] do
     end
 
     it do
-      get "/authorized", {user: "", uri: "/restricted-by-client-ip", ip: "10.1.16.2"}
+      get "/authorized", {user: "", uri: "/restricted-by-client-ip/", ip: "10.1.16.2"}
       body = JSON.parse(last_response.body, symbolize_names: true)
       expect(body).to eq({determination: "allowed"})
     end

--- a/lauth/spec/support/factories/collection.rb
+++ b/lauth/spec/support/factories/collection.rb
@@ -11,4 +11,9 @@ Factory.define(:collection, struct_namespace: Lauth) do |f|
     t.uniqueIdentifier "lauth-by-username"
     t.association(:locations, :restricted_by_username, count: 1)
   end
+
+  f.trait(:restricted_by_client_ip) do |t|
+    t.uniqueIdentifier "lauth-by-client-ip"
+    t.association(:locations, :restricted_by_client_ip, count: 1)
+  end
 end

--- a/lauth/spec/support/factories/location.rb
+++ b/lauth/spec/support/factories/location.rb
@@ -9,4 +9,8 @@ Factory.define(:location, struct_namespace: Lauth) do |f|
   f.trait(:restricted_by_username) do |t|
     t.dlpsPath "/restricted-by-username%"
   end
+
+  f.trait(:restricted_by_client_ip) do |t|
+    t.dlpsPath "/restricted-by-client-ip%"
+  end
 end

--- a/lauth/spec/support/factories/network.rb
+++ b/lauth/spec/support/factories/network.rb
@@ -3,6 +3,9 @@ require "ipaddr"
 Factory.define(:network, struct_namespace: Lauth) do |f|
   f.sequence(:uniqueIdentifier) { |n| n }
   f.dlpsCIDRAddress { "0.0.0.0/0" }
+
+  # ROM-factory cares about the literal name of the block parameter in order to
+  # bring in the data from that field, so we can't use different variable names here.
   # standard:disable Naming/VariableName, Naming/BlockParameterName
   f.dlpsAddressStart { |dlpsCIDRAddress| IPAddr.new(dlpsCIDRAddress).to_range.first.to_i }
   f.dlpsAddressEnd { |dlpsCIDRAddress| IPAddr.new(dlpsCIDRAddress).to_range.last.to_i }

--- a/lauth/spec/support/factories/network.rb
+++ b/lauth/spec/support/factories/network.rb
@@ -1,0 +1,20 @@
+require "ipaddr"
+
+Factory.define(:network, struct_namespace: Lauth) do |f|
+  f.sequence(:uniqueIdentifier) { |n| n }
+  f.dlpsCIDRAddress { "0.0.0.0/0" }
+  f.dlpsAddressStart { |dlpsCIDRAddress| IPAddr.new(dlpsCIDRAddress).to_range.first.to_i }
+  f.dlpsAddressEnd { |dlpsCIDRAddress| IPAddr.new(dlpsCIDRAddress).to_range.last.to_i }
+  f.dlpsAccessSwitch "allow"
+  f.lastModifiedTime Time.now
+  f.lastModifiedBy "root"
+  f.dlpsDeleted "f"
+
+  f.trait(:for_collection) do |t|
+    t.association(:collection)
+  end
+
+  f.trait(:for_institution) do |t|
+    t.association(:institution)
+  end
+end

--- a/lauth/spec/support/factories/network.rb
+++ b/lauth/spec/support/factories/network.rb
@@ -3,8 +3,11 @@ require "ipaddr"
 Factory.define(:network, struct_namespace: Lauth) do |f|
   f.sequence(:uniqueIdentifier) { |n| n }
   f.dlpsCIDRAddress { "0.0.0.0/0" }
+  # standard:disable Naming/VariableName, Naming/BlockParameterName
   f.dlpsAddressStart { |dlpsCIDRAddress| IPAddr.new(dlpsCIDRAddress).to_range.first.to_i }
   f.dlpsAddressEnd { |dlpsCIDRAddress| IPAddr.new(dlpsCIDRAddress).to_range.last.to_i }
+  # standard:enable Naming/VariableName, Naming/BlockParameterName
+
   f.dlpsAccessSwitch "allow"
   f.lastModifiedTime Time.now
   f.lastModifiedBy "root"

--- a/test/restrictions/campus_network_spec.rb
+++ b/test/restrictions/campus_network_spec.rb
@@ -5,4 +5,98 @@ RSpec.describe "Access to resources restricted to a known network" do
   #
   # We should test inside and outside of a contiguous range and within a denied
   # subnet inside a larger network.
+  # We test inside and outside of a contiguous range and within a denied
+  # subnet inside a larger network.
+  #
+  # Thus, there are three cases
+  # in_range?   in_subnet?
+  # yes         no
+  # yes         yes
+  # no          n/a
+  #
+  # outer   inner
+  # allow  allow "law school can access regular campus stuff
+  # allow  deny  "block some stupid law school computer
+  # deny   allow "let the law school access more stuff
+  # deny   deny  "no.
+  #
+  # Additionally, we should test that the ip range code is bypassed for a
+  # user that is logged in. This can be done by
+
+  # TODO:
+  # so here's what we need:
+  # an institution in aa_inst
+  # a collection in aa_coll.
+  # a 'location' in aa_coll_obj that actually points to our test site (lit-ip)...?
+  # two network entries:
+  #   1. big allowed one
+  #   2. smaller denied one bisecting [1]
+  # an aa_may_access entry that specifies coll, inst; leaves userid, user_group null
+  # (and an institution granted access to the collection),
+
+  let(:ip_content) { "allowed by authorized network" }
+  let(:path) { "/restricted-by-network/" }
+
+  # for a collection configured for ip auth
+  # a known user who is a member of an institution
+  # that has access to the collection
+  # given they are outside the configured networks,
+  # then they are denied
+
+  context "given a collection open to a campus network" do
+
+    it "is allowed within the campus network" do
+      response = site.get(path) { |req| req.headers["X-Client-IP"] = "10.1.16.44" }
+      expect(response.status).to eq HttpCodes::OK
+      expect(response.body).to include ip_content
+    end
+
+    it "is denied outside the campus network" do
+      response = site.get(path) { |req| req.headers["X-Client-IP"] = "10.1.8.30" }
+      expect(response.status).to eq HttpCodes::FORBIDDEN
+    end
+
+  end
+
+  xit "does not deny an authorized user" do
+    response = site.get("/user/") { |req| req.headers["X-Client-IP"] = "17.17.17.1" }
+    expect(response.status).to eq HttpCodes::OK
+    expect(response.body).to include user_content
+  end
+
+  xit "is denied by default" do
+    response = site.get(path) { |req| req.headers["X-Client-IP"] = "3.3.3.3" }
+    expect(response.status).to eq HttpCodes::UNAUTHORIZED # forbidden?
+  end
+
+  xit "is allowd within specified ranges (<)" do
+    response = site.get(path) { |req| req.headers["X-Client-IP"] = "6.1.1.1" }
+    expect(response.status).to eq HttpCodes::OK
+    expect(response.body).to include ip_content
+  end
+
+  # ensure assigning 6.1.1.2/32 respects the 32 cidr
+  xit "is allowd within specified ranges (>)" do
+    response = site.get(path) { |req| req.headers["X-Client-IP"] = "6.1.1.3" }
+    expect(response.status).to eq HttpCodes::OK
+    expect(response.body).to include ip_content
+  end
+
+  xit "is denied within nested allow>deny ranges" do
+    response = site.get(path) { |req| req.headers["X-Client-IP"] = "6.1.1.2" }
+    expect(response.status).to eq HttpCodes::UNAUTHORIZED # forbidden?
+  end
+
+  xit "is allowd within nested deny>allow ranges" do
+    response = site.get(path) { |req| req.headers["X-Client-IP"] = "7.1.1.9" }
+    expect(response.status).to eq HttpCodes::OK
+    expect(response.body).to include ip_content
+  end
+
+  private
+
+  def site
+    @site ||= Faraday.new(TestSite::URL)
+  end
+
 end


### PR DESCRIPTION
* Add db/network.sql test fixture
* Add restricted-by-network test site apache config
* Ensure mod_remoteip does not ignore the ip
   
  It considered the 10. IPs to be internal and ignored them. By adding
  this directive, it knows to use them.

* GrantRepo correctly finds the smallest network
    
    * Adds tests for nested network (allow, deny) and (deny, allow)
      scenarios
    * Changes SQL ordering of networks from desc to asc, so that we find the
      smallest network instead of the largest.
    * Removes the unnecessary math extravaganza to calculate the cidr range
      number

* Rename for_user_and_uri to for (with named args)
* Move ipaddr calculation to factory

#### Open questions

* 401 vs 403 for responses. This is the path of least resistance to get this code merged. 
  I/we will need to run the tests against the test site, but that's not a meaningful thing
  to do until the test site loads the network.sql fixture. 
* should I squash these commits down to one?
