### PR TITLE
Enable proxy specs

### DIFF
--- a/apache/conf/test-site.conf
+++ b/apache/conf/test-site.conf
@@ -58,6 +58,8 @@
     AuthType RemoteUser
     ProxyPass "http://proxied-test-app.lauth.local:8008"
     ProxyPassReverse "http://proxied-test-app.lauth.local:8008"
+    RequestHeader set X-Authzd-Coll     %{AUTHZD_COLL}e
+    RequestHeader set X-Public-Coll     %{PUBLIC_COLL}e
     <RequireAll>
       Require valid-user
       Require lauth

--- a/db/delegation.sql
+++ b/db/delegation.sql
@@ -74,10 +74,19 @@ INSERT INTO aa_coll VALUES(
   'f' -- deleted
 );
 
--- we only need one location for these tests
+-- location for non-proxy scenarios
 INSERT INTO aa_coll_obj VALUES(
   'www.lauth.local', -- server hostname, not vhost
   '/lauth/test-site/cgi/printenv', -- dlpsPath
+  'target-cats', -- coll.uniqueIdentifier
+  CURRENT_TIMESTAMP, 'root', -- modified info
+  'f' -- deleted
+);
+
+-- location for proxy scenarios, where we match by uri
+INSERT INTO aa_coll_obj VALUES(
+  'www.lauth.local', -- server hostname, not vhost
+  '/app/proxied', -- dlpsPath
   'target-cats', -- coll.uniqueIdentifier
   CURRENT_TIMESTAMP, 'root', -- modified info
   'f' -- deleted

--- a/test/delegation/delegated_mode.rb
+++ b/test/delegation/delegated_mode.rb
@@ -24,14 +24,14 @@ RSpec.shared_examples "delegated mode" do
     end
 
     it "lists the matching public collections" do
-      list = parsed_body["PUBLIC_COLL"]
+      list = parsed_body[public_column]
       expect(list).to match_collection_string_format
       expect(tokenize_collection_string(list))
         .to include "public-cats"
     end
 
     it "lists the matching authorized collections" do
-      list = parsed_body["AUTHZD_COLL"]
+      list = parsed_body[authorized_column]
       expect(list).to match_collection_string_format
       expect(tokenize_collection_string(list))
         .to include "target-cats", "extra-cats", "extra-public-cats"
@@ -45,14 +45,14 @@ RSpec.shared_examples "delegated mode" do
     end
 
     it "lists the matching public collections" do
-      list = parsed_body["PUBLIC_COLL"]
+      list = parsed_body[public_column]
       expect(list).to match_collection_string_format
       expect(tokenize_collection_string(list))
         .to include "public-cats", "extra-public-cats"
     end
 
     it "lists the matching authorized collections" do
-      list = parsed_body["AUTHZD_COLL"]
+      list = parsed_body[authorized_column]
       expect(list).to eq ":"
     end
   end

--- a/test/delegation/hosted_spec.rb
+++ b/test/delegation/hosted_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe "A web server-hosted application in delegated mode" do
 
   include_examples "delegated mode" do
     let(:url) { "/hosted" }
+    let(:authorized_column) { "AUTHZD_COLL" }
+    let(:public_column) { "PUBLIC_COLL" }
     let(:parsed_body) do
       response.body
         .split("\n")

--- a/test/delegation/proxied_spec.rb
+++ b/test/delegation/proxied_spec.rb
@@ -1,18 +1,21 @@
 require_relative "delegated_mode"
 
 # TODO: Currently skipped pending figuring out how to put the data into the headers.
-RSpec.describe "A proxied application in delegated mode", :skip do
+RSpec.describe "A proxied application in delegated mode" do
   # These are apps external to the web server, configured for reverse proxy.
   # They should receive identity and the authorized collections in forwarded
   # headers.
 
   include_examples "delegated mode" do
     let(:url) { "/app/proxied" }
+    let(:authorized_column) { "X-Authzd-Coll" }
+    let(:public_column) { "X-Public-Coll" }
     let(:parsed_body) do
       response.body
         .split("\n")
         .map { |s| s.split(":", 2) }
         .to_h
+        .transform_values(&:lstrip)
     end
   end
 end

--- a/test/support/collection_string_helpers.rb
+++ b/test/support/collection_string_helpers.rb
@@ -19,7 +19,7 @@ module CollectionStringHelpers
       COLLECTION_FORMAT.match? actual
     end
     failure_message do |actual|
-      "#{actual} did not match the format (#{COLLECTION_FORMAT})"
+      "<#{actual.class}>#{actual} did not match the format (#{COLLECTION_FORMAT})"
     end
   end
 end


### PR DESCRIPTION
Enables the proxied specs I'd already written, and gets them green. 

Currently this sets the headers from the environment with RequestHeader directives in the apache config. Let me know if that's the wrong way to do it.

Setting headers_out didn't actually seem to do anything.