### PR TITLE
Authorization: Bearer Token

### DIFF
--- a/apache/client/include/lauth/api_client.hpp
+++ b/apache/client/include/lauth/api_client.hpp
@@ -10,8 +10,9 @@
 namespace mlibrary::lauth {
   class ApiClient {
     public:
-      ApiClient(const std::string& url) : client(std::make_unique<HttpClient>(url)) {};
+      ApiClient(const std::string& url, const std::string& bearerToken) : client(std::make_unique<HttpClient>(url)), bearerToken(bearerToken) {};
       ApiClient(std::unique_ptr<HttpClient>&& client) : client(std::move(client)) {};
+      ApiClient(std::unique_ptr<HttpClient>&& client, const std::string& bearerToken) : client(std::move(client)), bearerToken(bearerToken) {};
       ApiClient(const ApiClient&) = delete;
       ApiClient& operator=(const ApiClient&) = delete;
       ApiClient(ApiClient&&) = delete;
@@ -22,6 +23,7 @@ namespace mlibrary::lauth {
 
     protected:
       std::unique_ptr<HttpClient> client;
+      const std::string bearerToken;
   };
 }
 

--- a/apache/client/include/lauth/authorizer.hpp
+++ b/apache/client/include/lauth/authorizer.hpp
@@ -11,7 +11,7 @@
 namespace mlibrary::lauth {
   class Authorizer {
     public:
-      Authorizer(const std::string& url) : client(std::make_unique<ApiClient>(url)) {};
+      Authorizer(const std::string& url, const std::string& bearerToken) : client(std::make_unique<ApiClient>(url, bearerToken)) {};
       Authorizer(std::unique_ptr<ApiClient>&& client) : client(std::move(client)) {};
       Authorizer(const Authorizer&) = delete;
       Authorizer& operator=(const Authorizer&) = delete;

--- a/apache/client/include/lauth/http_client.hpp
+++ b/apache/client/include/lauth/http_client.hpp
@@ -2,6 +2,7 @@
 #define __LAUTH_HTTP_CLIENT_HPP__
 
 #include "lauth/http_params.hpp"
+#include "lauth/http_headers.hpp"
 
 #include <optional>
 #include <string>
@@ -14,6 +15,8 @@ namespace mlibrary::lauth {
 
       virtual std::optional<std::string> get(const std::string &path);
       virtual std::optional<std::string> get(const std::string &path, const HttpParams &params);
+      virtual std::optional<std::string> get(const std::string &path, const HttpHeaders &headers);
+      virtual std::optional<std::string> get(const std::string &path, const HttpParams &params, const HttpHeaders &headers);
 
     protected:
       const std::string baseUrl;

--- a/apache/client/include/lauth/http_headers.hpp
+++ b/apache/client/include/lauth/http_headers.hpp
@@ -1,0 +1,23 @@
+#ifndef __LAUTH_HTTP_HEADERS_HPP__
+#define __LAUTH_HTTP_HEADERS_HPP__
+
+#include <map>
+#include <string>
+
+namespace mlibrary::lauth {
+  namespace detail {
+    // https://github.com/yhirose/cpp-httplib/blob/3b6597bba913d51161383657829b7e644e59c006/httplib.h#L315
+    struct ci {
+      bool operator()(const std::string &s1, const std::string &s2) const {
+        return std::lexicographical_compare(s1.begin(), s1.end(), s2.begin(),
+                                            s2.end(),
+                                            [](unsigned char c1, unsigned char c2) {
+                                              return ::tolower(c1) < ::tolower(c2);
+                                            });
+      }
+    };
+  }
+  using HttpHeaders = std::multimap<std::string, std::string, detail::ci>;
+}
+
+#endif // __LAUTH_HTTP_HEADERS_HPP__

--- a/apache/client/include/lauth/http_params.hpp
+++ b/apache/client/include/lauth/http_params.hpp
@@ -1,8 +1,6 @@
 #ifndef __LAUTH_HTTP_PARAMS_HPP__
 #define __LAUTH_HTTP_PARAMS_HPP__
 
-#include <httplib.h>
-
 #include <map>
 #include <string>
 

--- a/apache/client/include/lauth/json_conversions.hpp
+++ b/apache/client/include/lauth/json_conversions.hpp
@@ -2,7 +2,6 @@
 #define __LAUTH_JSON_CONVERSIONS_HPP__
 
 #include "lauth/json.hpp"
-
 #include "lauth/authorization_result.hpp"
 
 namespace mlibrary::lauth {

--- a/apache/client/include/lauth/request.hpp
+++ b/apache/client/include/lauth/request.hpp
@@ -1,5 +1,6 @@
 #ifndef __LAUTH_REQUEST_HPP__
 #define __LAUTH_REQUEST_HPP__
+
 #include <string>
 
 namespace mlibrary::lauth {
@@ -9,5 +10,6 @@ namespace mlibrary::lauth {
     std::string user;
   };
 }
-#endif
+
+#endif // __LAUTH_REQUEST_HPP__
 

--- a/apache/client/meson.build
+++ b/apache/client/meson.build
@@ -48,6 +48,7 @@ install_headers(
   'include/lauth/authorizer.hpp',
   'include/lauth/http_client.hpp',
   'include/lauth/http_params.hpp',
+  'include/lauth/http_headers.hpp',
   'include/lauth/json_conversions.hpp',
   'include/lauth/request.hpp',
   subdir: 'lauth')

--- a/apache/client/src/lauth/api_client.cpp
+++ b/apache/client/src/lauth/api_client.cpp
@@ -14,7 +14,13 @@ namespace mlibrary::lauth {
       {"user", req.user}
     };
 
-    auto result = client->get("/authorized", params);
+    std::string authorization = "Bearer " + bearerToken;
+
+    HttpHeaders headers {
+      {"Authorization", authorization}
+    };
+
+    auto result = client->get("/authorized", params, headers);
 
     try
     {

--- a/apache/client/src/lauth/http_client.cpp
+++ b/apache/client/src/lauth/http_client.cpp
@@ -5,12 +5,16 @@
 #include <httplib.h>
 
 #include "lauth/http_params.hpp"
+#include "lauth/http_headers.hpp"
 
 namespace mlibrary::lauth {
-  std::optional<std::string> HttpClient::get(const std::string& path) {
+  std::optional<std::string> HttpClient::get(const std::string& path, const HttpParams& params, const HttpHeaders& headers) {
     httplib::Client client(baseUrl);
 
-    auto res = client.Get(path);
+    // using Headers = std::multimap<std::string, std::string, detail::ci>;
+    httplib::Headers marshal_headers ( headers.begin(), headers.end() );
+
+    auto res = client.Get(path, params, marshal_headers);
     if (res)
       return res->body;
     else
@@ -18,13 +22,14 @@ namespace mlibrary::lauth {
   }
 
   std::optional<std::string> HttpClient::get(const std::string& path, const HttpParams& params) {
-    httplib::Client client(baseUrl);
-    httplib::Headers headers;
+     return get(path, params, HttpHeaders{});
+  }
 
-    auto res = client.Get(path, params, headers);
-    if (res)
-      return res->body;
-    else
-      return std::nullopt;
+  std::optional<std::string> HttpClient::get(const std::string& path, const HttpHeaders& headers) {
+    return get(path, HttpParams{}, headers);
+  }
+
+  std::optional<std::string> HttpClient::get(const std::string& path) {
+     return get(path, HttpParams{}, HttpHeaders{});
   }
 }

--- a/apache/client/test/lauth/api_client_test.cpp
+++ b/apache/client/test/lauth/api_client_test.cpp
@@ -28,10 +28,14 @@ TEST(ApiClient, HttpRequestByApiClientIsCorrect) {
       {"user", req.user}
   };
 
+  HttpHeaders headers {
+      {"Authorization", "Bearer dGVzdA=="}
+  };
+
   auto body = R"({"determination":"allowed"})";
 
-  EXPECT_CALL(*client, get("/authorized", params)).WillOnce(Return(body));
-  ApiClient api_client(std::move(client));
+  EXPECT_CALL(*client, get("/authorized", params, headers)).WillOnce(Return(body));
+  ApiClient api_client(std::move(client), "dGVzdA==");
 
   api_client.authorize(req);
 }
@@ -40,7 +44,7 @@ TEST(ApiClient, DeterminationAllowedReturnsTrue) {
   auto client = std::make_unique<MockHttpClient>();
   auto body = R"({"determination":"allowed"})";
 
-  EXPECT_CALL(*client, get(_, _)).WillOnce(Return(body));
+  EXPECT_CALL(*client, get(_, _, _)).WillOnce(Return(body));
   ApiClient api_client(std::move(client));
 
   auto result = api_client.authorize(Request());
@@ -51,7 +55,7 @@ TEST(ApiClient, DeterminationDeniedReturnsFalse) {
   auto client = std::make_unique<MockHttpClient>();
   auto body = R"({"determination":"denied"})";
 
-  EXPECT_CALL(*client, get(_, _)).WillOnce(Return(body));
+  EXPECT_CALL(*client, get(_, _, _)).WillOnce(Return(body));
   ApiClient api_client(std::move(client));
 
   auto result = api_client.authorize(Request());
@@ -62,7 +66,7 @@ TEST(ApiClient, MismatchedJsonReturnsFalse) {
   auto client = std::make_unique<MockHttpClient>();
   auto body = R"({"should_ignore_this_key":"allowed"})";
 
-  EXPECT_CALL(*client, get(_, _)).WillOnce(Return(body));
+  EXPECT_CALL(*client, get(_, _, _)).WillOnce(Return(body));
   ApiClient api_client(std::move(client));
 
   auto result = api_client.authorize(Request());
@@ -73,7 +77,7 @@ TEST(ApiClient, MalformedJsonReturnsFalse) {
   auto client = std::make_unique<MockHttpClient>();
   auto body = R"({"should_ignore_this_key":"allowed",)";
 
-  EXPECT_CALL(*client, get(_, _)).WillOnce(Return(body));
+  EXPECT_CALL(*client, get(_, _, _)).WillOnce(Return(body));
   ApiClient api_client(std::move(client));
 
   auto result = api_client.authorize(Request());
@@ -84,7 +88,7 @@ TEST(ApiClient, EmptyBodyReturnsFalse) {
   auto client = std::make_unique<MockHttpClient>();
   auto body = "";
 
-  EXPECT_CALL(*client, get(_, _)).WillOnce(Return(body));
+  EXPECT_CALL(*client, get(_, _, _)).WillOnce(Return(body));
   ApiClient api_client(std::move(client));
 
   auto result = api_client.authorize(Request());

--- a/apache/client/test/lauth/http_client_test.cpp
+++ b/apache/client/test/lauth/http_client_test.cpp
@@ -73,3 +73,15 @@ TEST(HttpClient, GetRequestWithMultipleParametersEncodesThem) {
 
   EXPECT_THAT(*response, Eq(R"({"foo":"bar","something":"else"})"));
 }
+
+TEST(HttpClient, GetRequestWithAuthorizationHeaderEncodesIt) {
+  HttpClient client(MOCK_API_URL());
+
+  HttpParams params;
+  params.emplace("foo", "bar");
+  HttpHeaders headers;
+  headers.emplace("Authorization", "Bearer dGVzdA==");
+  auto response = client.get("/authorization", params, headers);
+
+  EXPECT_THAT(*response, Eq(R"({"Bearer":"dGVzdA=="})"));
+}

--- a/apache/client/test/lauth/mocks.hpp
+++ b/apache/client/test/lauth/mocks.hpp
@@ -5,6 +5,7 @@
 #include "lauth/authorization_result.hpp"
 #include "lauth/http_client.hpp"
 #include "lauth/http_params.hpp"
+#include "lauth/http_headers.hpp"
 
 #include <optional>
 
@@ -15,6 +16,8 @@ class MockHttpClient : public HttpClient {
     MockHttpClient() : HttpClient("http://api.invalid") {};
     MOCK_METHOD(std::optional<std::string>, get, (const std::string&), (override));
     MOCK_METHOD(std::optional<std::string>, get, (const std::string&, const HttpParams&), (override));
+    MOCK_METHOD(std::optional<std::string>, get, (const std::string&, const HttpHeaders&), (override));
+    MOCK_METHOD(std::optional<std::string>, get, (const std::string&, const HttpParams&, const HttpHeaders&), (override));
 };
 
 class MockApiClient : public ApiClient {

--- a/apache/client/test/mock_service.cpp
+++ b/apache/client/test/mock_service.cpp
@@ -35,6 +35,22 @@ int main(int argc, char **argv) {
     res.set_content(params.dump().c_str(), "application/json");
   });
 
+  // Echo GET authorization as json object
+  server.Get("/authorization", [](const Request &req, Response &res) {
+    auto buffer = req.get_header_value("Authorization");
+
+    auto pos = buffer.find(" ");
+    auto key = buffer.substr(0, pos);
+    buffer.erase(0, pos + 1);
+    auto value = buffer;
+
+    json auth;
+    auth[key] = value;
+
+    std::cout << "GET /authorization" << std::endl;
+    res.set_content(auth.dump().c_str(), "application/json");
+  });
+
   server.Get("/users/authorized/is_allowed", [](const Request &, Response &res) {
     std::cout << "GET /users/authorized/is_allowed" << std::endl;
     res.set_content("yes", "text/plain");

--- a/apache/debpkgs/mod-authn-remoteuser/etc/apache2/mods-available/authn_remoteuser.conf
+++ b/apache/debpkgs/mod-authn-remoteuser/etc/apache2/mods-available/authn_remoteuser.conf
@@ -8,5 +8,3 @@
   # RemoteUserAnonymousUsername lauth-nobody
 
 </IfModule>
-
-# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/apache/debpkgs/mod-lauth/etc/apache2/mods-available/lauth.conf
+++ b/apache/debpkgs/mod-lauth/etc/apache2/mods-available/lauth.conf
@@ -1,0 +1,6 @@
+<IfModule lauth_module>
+
+  LauthApiUrl http://app.lauth.local:2300
+  LauthApiToken TG9yZCBvZiB0aGUgUmluZ3MK
+
+</IfModule>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
         UID: ${UID:-1000}
         GID: ${GID:-1000}
     environment:
+      - BEARER_TOKEN=TG9yZCBvZiB0aGUgUmluZ3MK
       - DATABASE_URL=mysql2://lauth:lauth@db.lauth.local:3306/lauth_demo
     hostname: app.lauth.local
     networks:

--- a/lauth/.env.development
+++ b/lauth/.env.development
@@ -1,2 +1,3 @@
+BEARER_TOKEN=Si5SLlIuIFRvbGtpZW4K
 DATABASE_URL=mysql2://lauth:lauth@db.lauth.local:3306/lauth_development
 SESSION_SECRET=__local_development_secret_only__

--- a/lauth/.env.test
+++ b/lauth/.env.test
@@ -1,2 +1,3 @@
+BEARER_TOKEN=VGhlIEhvYmJpdAo=
 DATABASE_URL=mysql2://lauth:lauth@db.lauth.local:3306/lauth_test
 SESSION_SECRET=__local_development_secret_only__

--- a/lauth/app/actions/authorize.rb
+++ b/lauth/app/actions/authorize.rb
@@ -4,15 +4,27 @@ module Lauth
       def handle(request, response)
         response.format = :json
 
-        result = Lauth::Ops::Authorize.new(
-          request: Lauth::Access::Request.new(
-            user: request.params[:user],
-            uri: request.params[:uri],
-            client_ip: request.params[:ip]
-          )
-        ).call
+        if request.has_header?("HTTP_AUTHORIZATION")
+          if request.get_header("HTTP_AUTHORIZATION") == "Bearer " + App.app["settings"].bearer_token
+            result = Lauth::Ops::Authorize.new(
+              request: Lauth::Access::Request.new(
+                user: request.params[:user],
+                uri: request.params[:uri],
+                client_ip: request.params[:ip]
+              )
+            ).call
 
-        response.body = result.to_h.to_json
+            response.body = result.to_h.to_json
+          else
+            App.app["logger"].error("Request HTTP authorization failed.")
+            response.status = 401 # Unauthorized
+            response.body = Lauth::Access::Request.new.to_h.to_json
+          end
+        else
+          App.app["logger"].error("Request missing HTTP authorization header.")
+          response.status = 401 # Unauthorized
+          response.body = Lauth::Access::Request.new.to_h.to_json
+        end
       end
     end
   end

--- a/lauth/config/settings.rb
+++ b/lauth/config/settings.rb
@@ -2,6 +2,7 @@
 
 module Lauth
   class Settings < Hanami::Settings
+    setting :bearer_token, constructor: Types::String
     setting :database_url, constructor: Types::String
     setting :session_secret, constructor: Types::String
   end

--- a/lauth/spec/requests/authorized_any_spec.rb
+++ b/lauth/spec/requests/authorized_any_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "/authorized by username or client-ip", type: [:request, :databas
   # @param ip [String]
   # @return [Hash] the response body after json parsing
   def request(from:, as:)
-    get "/authorized", {user: as.to_s, uri: "/restricted-by-username-or-client-ip", ip: from}
+    get "/authorized", {user: as.to_s, uri: "/restricted-by-username-or-client-ip", ip: from}, {"HTTP_AUTHORIZATION" => "Bearer VGhlIEhvYmJpdAo="}
     JSON.parse(last_response.body, symbolize_names: true)
   end
 end

--- a/lauth/spec/requests/authorized_client_ip_spec.rb
+++ b/lauth/spec/requests/authorized_client_ip_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe "/authorized by client-ip", type: [:request, :database] do
   # @param ip [String]
   # @return [Hash] the response body after json parsing
   def request_from(ip)
-    get "/authorized", {user: "", uri: "/restricted-by-client-ip", ip: ip}
+    get "/authorized", {user: "", uri: "/restricted-by-client-ip", ip: ip}, {"HTTP_AUTHORIZATION" => "Bearer VGhlIEhvYmJpdAo="}
     JSON.parse(last_response.body, symbolize_names: true)
   end
 end

--- a/lauth/spec/requests/authorized_spec.rb
+++ b/lauth/spec/requests/authorized_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "/authorized", type: [:request, :database] do
     let!(:grant) { Factory[:grant, :for_user, user: user, collection: collection] }
 
     it do
-      get "/authorized", {user: "lauth-allowed", uri: "/restricted-by-username/"}
+      get "/authorized", {user: "lauth-allowed", uri: "/restricted-by-username/"}, {"HTTP_AUTHORIZATION" => "Bearer VGhlIEhvYmJpdAo="}
       body = JSON.parse(last_response.body, symbolize_names: true)
 
       expect(body).to include(determination: "allowed")
@@ -33,7 +33,7 @@ RSpec.describe "/authorized", type: [:request, :database] do
     let!(:grant) { Factory[:grant, :for_group, group: group, collection: collection] }
 
     it do
-      get "/authorized", {user: "lauth-group-member", uri: "/restricted-by-username/"}
+      get "/authorized", {user: "lauth-group-member", uri: "/restricted-by-username/"}, {"HTTP_AUTHORIZATION" => "Bearer VGhlIEhvYmJpdAo="}
 
       body = JSON.parse(last_response.body, symbolize_names: true)
       expect(body).to include(determination: "allowed")

--- a/lauth/spec/requests/delegated_spec.rb
+++ b/lauth/spec/requests/delegated_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "/authorized delegation", type: [:request, :database] do
 
   # @return [Hash] the response body after json parsing
   def request(as:)
-    get "/authorized", {user: as.to_s, uri: "/delegated"}
+    get "/authorized", {user: as.to_s, uri: "/delegated"}, {"HTTP_AUTHORIZATION" => "Bearer VGhlIEhvYmJpdAo="}
     JSON.parse(last_response.body, symbolize_names: true)
   end
 end


### PR DESCRIPTION
Added configuration of Lauth API URL and Token to Lauth Apache Module (and DEBIAN package).
Added configuration (settings) and check for HTTP authorization bearer token in Lauth authorize action (with error logging).

NOTE: In this implementation the “Bearer Token” is a secret known to the Lauth Apache Module and Lauth API Application. There is no encrypted credentials/payloads in the base 64 encoded token, just an Easter Egg.