### PR TITLE
Remove pre-fetching for grant associations

### DIFF
--- a/lauth/app/repositories/grant_repo.rb
+++ b/lauth/app/repositories/grant_repo.rb
@@ -14,8 +14,7 @@ module Lauth
           .join(collections.name.dataset, uniqueIdentifier: grants[:coll], dlpsDeleted: "f")
           .where(collections[:dlpsClass] => collection_class)
 
-        rel = grants.class.new(ds)
-        rel.to_a
+        grants.class.new(ds).to_a
       end
 
       def for(username:, collection:, client_ip: nil)
@@ -25,8 +24,7 @@ module Lauth
         ds = base_grants_for(username: username, network: smallest_network)
           .where(grants[:coll] => collection.uniqueIdentifier)
 
-        rel = grants.class.new(ds)
-        rel.combine(:user, institutions: {institution_memberships: :users}).to_a
+        grants.class.new(ds).to_a
       end
 
       private

--- a/lauth/spec/repositories/grant_repo_spec.rb
+++ b/lauth/spec/repositories/grant_repo_spec.rb
@@ -59,15 +59,6 @@ RSpec.describe Lauth::Repositories::GrantRepo, type: :database do
 
           expect(grants).to eq []
         end
-
-        # TODO: extract this
-        describe "grant association loading" do
-          subject(:found_grant) { repo.for(username: "lauth-allowed", collection: collection).first }
-
-          it "loads user" do
-            expect(found_grant.user.userid).to eq grant.user.userid
-          end
-        end
       end
 
       context "with a member of an authorized institution" do


### PR DESCRIPTION
When finding grants, we were loading associations for some general convenience. However, we do not inspect the grants in detail for our current use cases -- we supply very specific join/where conditions and check for their existence as the implementation of the authorization rules.

This preloading would be useful for building an administrative interface, for example, but is unncessary now. The reason to remove it is to avoid complexity and a performance problem introduced by fetching the institution memberships: we were loading all of them for any matched institution and doing an in-memory join on the object graph. In production, that can be a giant list, consuming excessive time and memory.

This problem can be solved by "adjusting the combine", applying appropriate pieces of the filter conditions the association nodes, but it is not worth doing now. We would be doing extra work and extra queries to throw the data away.