### PR TITLE
Improve query performance by adjusting join conditions

### DIFF
--- a/lauth/app/repositories/grant_repo.rb
+++ b/lauth/app/repositories/grant_repo.rb
@@ -46,10 +46,10 @@ module Lauth
           .where(grants[:dlpsDeleted].is("f"))
           .left_join(users.name.dataset, userid: grants[:userid], dlpsDeleted: "f")
           .left_join(institutions.name.dataset, uniqueIdentifier: grants[:inst], dlpsDeleted: "f")
-          .left_join(institution_memberships.name.dataset, inst: :uniqueIdentifier, dlpsDeleted: "f")
+          .left_join(institution_memberships.name.dataset, inst: :uniqueIdentifier, userid: username, dlpsDeleted: "f")
           .left_join(Sequel.as(users.name.dataset, :inst_users), userid: :userid, dlpsDeleted: "f")
           .left_join(groups.name.dataset, uniqueIdentifier: grants[:user_grp], dlpsDeleted: "f")
-          .left_join(group_memberships.name.dataset, user_grp: :uniqueIdentifier, dlpsDeleted: "f")
+          .left_join(group_memberships.name.dataset, user_grp: :uniqueIdentifier, userid: username, dlpsDeleted: "f")
           .left_join(Sequel.as(users.name.dataset, :group_users), userid: :userid, dlpsDeleted: "f")
           .left_join(Sequel.as(network, :smallest), inst: institutions[:uniqueIdentifier])
           .where(
@@ -60,13 +60,11 @@ module Lauth
               ),
               Sequel.&(
                 Sequel.~(institutions[:uniqueIdentifier] => nil),
-                Sequel.~(Sequel[:inst_users][:userid] => nil),
-                {institution_memberships[:userid] => username}
+                Sequel.~(Sequel[:inst_users][:userid] => nil)
               ),
               Sequel.&(
                 Sequel.~(groups[:uniqueIdentifier] => nil),
-                Sequel.~(Sequel[:group_users][:userid] => nil),
-                {group_memberships[:userid] => username}
+                Sequel.~(Sequel[:group_users][:userid] => nil)
               ),
               Sequel.&(
                 Sequel.~(Sequel[:smallest][:inst] => nil),


### PR DESCRIPTION
We originally attempted to map everything out with left joins and then apply the conditions that filter down to at most one matching row each (for direct user grants, institution memberships, network, or group memberships). It was conceptually correct, but the query optimizer did not apply the WHERE fully through memberships joins. This meant that, for institutions with many members, there was a cartesian product of grants to memberships to process.

There are multiple approaches that solve this problem, including adjusting the associativity/grouping of the joins (so that the memberships inner join the users, thereby left joining at most one membership-user row). However, the flat construction of the ROM query code is attractive for its relative simplicity. By applying the literal username comparison at the institution and group memberships, we achieve the goal of left joining at most one membership.

In production-scale measurements, this amounts to the same results being returned on the order of 2,000 times faster (e.g., 50ms vs 100s).