### PR TITLE
Add debug logging throughout API requests

### DIFF
--- a/apache/client/include/lauth/http_client.hpp
+++ b/apache/client/include/lauth/http_client.hpp
@@ -20,6 +20,9 @@ namespace mlibrary::lauth {
 
     protected:
       const std::string baseUrl;
+      void requestOk(const std::string& path, std::size_t size);
+      void requestNotOk(const std::string& path, int status);
+      void requestFailed(const std::string& path, const std::string& error);
   };
 }
 

--- a/apache/client/include/lauth/logging.hpp
+++ b/apache/client/include/lauth/logging.hpp
@@ -1,0 +1,147 @@
+#ifndef __LAUTH_LOGGING_HPP__
+#define __LAUTH_LOGGING_HPP__
+
+#include <iostream>
+#include <map>
+#include <memory>
+#include <string>
+#include <sstream>
+
+namespace mlibrary::lauth {
+  enum LogLevel {
+    FATAL = 0,
+    ERROR = 1,
+    WARN = 2,
+    INFO = 3,
+    DEBUG = 4,
+    TRACE = 5
+  };
+
+  const std::string LogLevels[] = {"FATAL", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"};
+
+  class LogSink {
+    public:
+      virtual ~LogSink() = default;
+      virtual void write(const std::string& level, const std::string& msg, const char* file, int line) = 0;
+      virtual void fatal(const std::string& msg, const char* file, int line) = 0;
+      virtual void error(const std::string& msg, const char* file, int line) = 0;
+      virtual void warn(const std::string& msg, const char* file, int line) = 0;
+      virtual void info(const std::string& msg, const char* file, int line) = 0;
+      virtual void debug(const std::string& msg, const char* file, int line) = 0;
+      virtual void trace(const std::string& msg, const char* file, int line) = 0;
+  };
+
+  class StdOut : public LogSink {
+    public:
+      virtual ~StdOut() = default;
+
+      void write(const std::string& level, const std::string& msg, const char* file, int line) override {
+        std::cout << "[" << level << "] " << file << "(" << line << "): " << msg << std::endl;
+      }
+
+      void fatal(const std::string& msg, const char* file, int line) override {
+        write(LogLevels[LogLevel::FATAL], msg, file, line);
+      }
+
+      void error(const std::string& msg, const char* file, int line) override {
+        write(LogLevels[LogLevel::ERROR], msg, file, line);
+      }
+
+      void warn(const std::string& msg, const char* file, int line) override {
+        write(LogLevels[LogLevel::WARN], msg, file, line);
+      }
+
+      void info(const std::string& msg, const char* file, int line) override {
+        write(LogLevels[LogLevel::INFO], msg, file, line);
+      }
+
+      void debug(const std::string& msg, const char* file, int line) override {
+        write(LogLevels[LogLevel::DEBUG], msg, file, line);
+      }
+
+      void trace(const std::string& msg, const char* file, int line) override {
+        write(LogLevels[LogLevel::TRACE], msg, file, line);
+      }
+  };
+
+  class NullLog : public LogSink {
+    public:
+      virtual ~NullLog() = default;
+      void write(const std::string&, const std::string&, const char*, int) override {}
+      void fatal(const std::string&, const char*, int) override {}
+      void error(const std::string&, const char*, int) override {}
+      void warn(const std::string&, const char*, int) override {}
+      void info(const std::string&, const char*, int) override {}
+      void debug(const std::string&, const char*, int) override {}
+      void trace(const std::string&, const char*, int) override {}
+  };
+
+  class Logger {
+    public:
+      Logger() : out(std::make_unique<NullLog>()) {};
+      Logger(std::unique_ptr<LogSink>&& out) : out(std::move(out)) {};
+
+      Logger(const Logger&) = delete;
+      Logger& operator=(const Logger&) = delete;
+      Logger(Logger&&) = delete;
+      Logger& operator=(const Logger&&) = delete;
+      virtual ~Logger() = default;
+
+      static void set(std::shared_ptr<Logger> logger) {
+        Logger::logger = logger;
+      }
+
+      static std::shared_ptr<Logger> get() {
+        if (!Logger::logger) {
+          Logger::logger = std::make_shared<Logger>();
+        }
+        return Logger::logger;
+      }
+
+      void fatal(const std::string& msg, const char* file, int line) {
+        out->fatal(msg, file, line);
+      }
+
+      void error(const std::string& msg, const char* file, int line) {
+        out->error(msg, file, line);
+      }
+
+      void warn(const std::string& msg, const char* file, int line) {
+        out->warn(msg, file, line);
+      }
+
+      void info(const std::string& msg, const char* file, int line) {
+        out->info(msg, file, line);
+      }
+
+      void debug(const std::string& msg, const char* file, int line) {
+        out->debug(msg, file, line);
+      }
+
+      void trace(const std::string& msg, const char* file, int line) {
+        out->trace(msg, file, line);
+      }
+
+    protected:
+      inline static std::shared_ptr<Logger> logger;
+      std::unique_ptr<LogSink> out;
+  };
+}
+
+#define LAUTH_DEBUG(msg)                       \
+  mlibrary::lauth::Logger::get()->debug(       \
+    static_cast<std::ostringstream&>(          \
+      std::ostringstream().flush() << msg      \
+    ).str(),                                   \
+    __FILE__, __LINE__                         \
+  )
+
+#define LAUTH_WARN(msg)                        \
+  mlibrary::lauth::Logger::get()->warn(        \
+    static_cast<std::ostringstream&>(          \
+      std::ostringstream().flush() << msg      \
+    ).str(),                                   \
+    __FILE__, __LINE__                         \
+  )
+
+#endif // __LAUTH_LOGGING_HPP__

--- a/apache/client/meson.build
+++ b/apache/client/meson.build
@@ -49,7 +49,9 @@ install_headers(
   'include/lauth/http_client.hpp',
   'include/lauth/http_params.hpp',
   'include/lauth/http_headers.hpp',
+  'include/lauth/json.hpp',
   'include/lauth/json_conversions.hpp',
+  'include/lauth/logging.hpp',
   'include/lauth/request.hpp',
   subdir: 'lauth')
 

--- a/apache/client/src/lauth/http_client.cpp
+++ b/apache/client/src/lauth/http_client.cpp
@@ -6,19 +6,29 @@
 
 #include "lauth/http_params.hpp"
 #include "lauth/http_headers.hpp"
+#include "lauth/logging.hpp"
 
 namespace mlibrary::lauth {
   std::optional<std::string> HttpClient::get(const std::string& path, const HttpParams& params, const HttpHeaders& headers) {
     httplib::Client client(baseUrl);
+    client.set_connection_timeout(5);
+    client.set_read_timeout(5);
 
     // using Headers = std::multimap<std::string, std::string, detail::ci>;
     httplib::Headers marshal_headers ( headers.begin(), headers.end() );
 
     auto res = client.Get(path, params, marshal_headers);
-    if (res)
+
+    if (res && res->status == 200) {
+      requestOk(path, res->body.size());
       return res->body;
-    else
+    } else if (res) {
+      requestNotOk(path, res->status);
       return std::nullopt;
+    } else {
+      requestFailed(path, httplib::to_string(res.error()));
+      return std::nullopt;
+    }
   }
 
   std::optional<std::string> HttpClient::get(const std::string& path, const HttpParams& params) {
@@ -31,5 +41,17 @@ namespace mlibrary::lauth {
 
   std::optional<std::string> HttpClient::get(const std::string& path) {
      return get(path, HttpParams{}, HttpHeaders{});
+  }
+
+  void HttpClient::requestOk(const std::string& path, std::size_t size) {
+    LAUTH_DEBUG("HTTP request to " << baseUrl << path << " succeeded; response length: " << size);
+  }
+
+  void HttpClient::requestNotOk(const std::string& path, int status) {
+    LAUTH_DEBUG("HTTP request to " << baseUrl << path << " succeeded but was not 200 OK; status: " << status);
+  }
+
+  void HttpClient::requestFailed(const std::string& path, const std::string& error) {
+    LAUTH_WARN("HTTP request to " << baseUrl << path << " failed: " << error);
   }
 }


### PR DESCRIPTION
This adds an indirect logging facility to the client and an implementation that is injected from the module. It uses a globally configured logger/singleton. The design is not perfect, but the invocations and outputs are decent. I didn't want to add a logging or formatting library at this time, but it's something to consider; there are a few promising options. The C++20 format header is not available under the current version of GCC, so we use basic stringstreams, rather than dealing with varargs or adding {fmt}.