### PR TITLE
Ensure that SSL support is enabled in HttpClient

### DIFF
--- a/apache/client/meson.build
+++ b/apache/client/meson.build
@@ -31,6 +31,13 @@ lauth_integration_tests = files([
   'test/lauth/http_client_test.cpp',
 ])
 
+os = host_machine.system()
+if os == 'darwin'
+  httplib_links = []
+else
+  httplib_links = ['-lssl', '-lcrypto']
+endif
+
 liblauth = shared_library(
   'lauth',
   lauth_sources,
@@ -39,8 +46,11 @@ liblauth = shared_library(
     cpp_httplib,
     json,
   ],
+  link_args: httplib_links,
   install: true,
 )
+
+liblauth_dep = declare_dependency(include_directories: lauth_includes, link_with: liblauth)
 
 install_headers(
   'include/lauth/api_client.hpp',
@@ -64,8 +74,9 @@ if get_option('tests')
       cpp_httplib,
       json,
       gtest,
-      gmock
-    ]
+      gmock,
+    ],
+    link_args: httplib_links,
   )
   test('lauth-test', tests)
 endif
@@ -80,16 +91,10 @@ if get_option('integration-tests')
       json,
       gtest,
       gmock
-      ]
-    )
+    ],
+    link_args: httplib_links,
+  )
   test('lauth-integration-test', integration_tests)
-endif
-
-os = host_machine.system()
-if os == 'darwin'
-  httplib_links = []
-else
-  httplib_links = ['-lssl', '-lcrypto']
 endif
 
 executable(
@@ -109,4 +114,15 @@ executable(
     cpp_httplib,
   ],
   link_args: httplib_links
+)
+
+executable(
+  'api-check',
+  files(['src/api_check.cpp']),
+  include_directories: lauth_includes,
+  dependencies: [
+    cpp_httplib,
+    liblauth_dep,
+  ],
+  link_args: httplib_links,
 )

--- a/apache/client/src/api_check.cpp
+++ b/apache/client/src/api_check.cpp
@@ -1,0 +1,35 @@
+#include <exception>
+#include <iostream>
+#include <map>
+#include <memory>
+
+#include <lauth/authorizer.hpp>
+#include <lauth/logging.hpp>
+
+using namespace mlibrary::lauth;
+
+int main(int argc, char **argv) {
+  if (argc != 6) {
+    std::cout << "Usage: api-check <host> <token> <uri> <ip> <username>" << std::endl;
+    return -1;
+  }
+
+  auto host = std::string(argv[1]);
+  auto token = std::string(argv[2]);
+  auto uri = std::string(argv[3]);
+  auto ip = std::string(argv[4]);
+  auto user = std::string(argv[5]);
+  std::cout << "Authorizing (via " << host << ") --  uri: " << uri << ", ip: " << ip << ", user: " << user << std::endl;
+
+  Logger::set(std::make_shared<Logger>(std::make_unique<StdOut>()));
+  auto auth = Authorizer(host, token);
+  Request req = Request {
+	  .ip = ip,
+	  .uri = uri,
+	  .user = user
+  };
+
+  auto result = auth.authorize(req);
+  std::cout << "Authorizer worked... determination: " << result["determination"] << std::endl;
+  return 0;
+}

--- a/apache/client/src/lauth/http_client.cpp
+++ b/apache/client/src/lauth/http_client.cpp
@@ -2,6 +2,10 @@
 
 #include <optional>
 
+#ifndef CPPHTTPLIB_OPENSSL_SUPPORT
+#define CPPHTTPLIB_OPENSSL_SUPPORT 1
+#endif
+
 #include <httplib.h>
 
 #include "lauth/http_params.hpp"

--- a/apache/client/test/lauth/http_client_test.cpp
+++ b/apache/client/test/lauth/http_client_test.cpp
@@ -14,6 +14,7 @@
 
 using testing::_;
 using testing::Eq;
+using testing::HasSubstr;
 using testing::IsTrue;
 
 using namespace mlibrary::lauth;
@@ -84,4 +85,12 @@ TEST(HttpClient, GetRequestWithAuthorizationHeaderEncodesIt) {
   auto response = client.get("/authorization", params, headers);
 
   EXPECT_THAT(*response, Eq(R"({"Bearer":"dGVzdA=="})"));
+}
+
+TEST(HttpClient, HttpsSchemeIsSupported) {
+  HttpClient client("https://example.com");
+
+  auto response = client.get("/");
+
+  EXPECT_THAT(*response, HasSubstr("Example Domain"));
 }


### PR DESCRIPTION
The http-check tool was working fine with HTTPS because it enabled the support before it included httplib.h. However, the HttpClient implementation did not, which mean that the whole of the shared library was not supporting HTTPS.

When using the API over HTTPS, this was silently crashing the module because of an uncaught exception. This would normally produce stdout or stderr output, but it is squelched by the Apache process management.

We add an additional api-check binary that enables a cursory check of using the Authorizer against an HTTP or HTTPS API instance from the command line.